### PR TITLE
feat: add issue_get_changelog tool for viewing issue history

### DIFF
--- a/mcp_tracker/mcp/tools.py
+++ b/mcp_tracker/mcp/tools.py
@@ -26,6 +26,7 @@ from mcp_tracker.tracker.proto.types.issues import (
     ChecklistItem,
     Issue,
     IssueAttachment,
+    IssueChangelog,
     IssueComment,
     IssueFieldsEnum,
     IssueLink,
@@ -341,6 +342,42 @@ def register_tools(settings: Settings, mcp: FastMCP[Any]):
 
         return await ctx.request_context.lifespan_context.issues.issue_get_checklist(
             issue_id,
+            auth=get_yandex_auth(ctx),
+        )
+
+    @mcp.tool(
+        description="Get changelog (history of changes) of a Yandex Tracker issue. "
+        "Returns list of changes including who made the change, when, and what fields were modified."
+    )
+    async def issue_get_changelog(
+        ctx: Context[Any, AppContext],
+        issue_id: IssueID,
+        per_page: Annotated[
+            int,
+            Field(
+                description="Number of changelog entries to return (default 50, max 100)",
+            ),
+        ] = 50,
+        field: Annotated[
+            str | None,
+            Field(
+                description="Filter by specific field name (e.g., 'status', 'assignee', 'priority')",
+            ),
+        ] = None,
+        change_type: Annotated[
+            str | None,
+            Field(
+                description="Filter by change type (e.g., 'IssueCreated', 'IssueUpdated', 'IssueCommentAdded')",
+            ),
+        ] = None,
+    ) -> list[IssueChangelog]:
+        check_issue_id(settings, issue_id)
+
+        return await ctx.request_context.lifespan_context.issues.issue_get_changelog(
+            issue_id,
+            per_page=per_page,
+            field=field,
+            change_type=change_type,
             auth=get_yandex_auth(ctx),
         )
 

--- a/mcp_tracker/tracker/proto/types/issues.py
+++ b/mcp_tracker/tracker/proto/types/issues.py
@@ -130,3 +130,29 @@ class ChecklistItem(BaseTrackerEntity):
     checklist_item_type: str | None = Field(
         None, validation_alias=AliasChoices("checklistItemType", "checklist_item_type")
     )
+
+
+class ChangelogFieldChange(BaseModel):
+    """Represents a single field change in changelog"""
+    field: str | None = Field(None, validation_alias=AliasChoices("field", "id"))
+    from_value: str | dict | list | None = Field(
+        None, validation_alias=AliasChoices("from", "from_value")
+    )
+    to_value: str | dict | list | None = Field(
+        None, validation_alias=AliasChoices("to", "to_value")
+    )
+
+
+class IssueChangelog(BaseTrackerEntity):
+    """Represents a changelog entry for an issue"""
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    updated_at: datetime.datetime | None = Field(
+        None, validation_alias=AliasChoices("updatedAt", "updated_at")
+    )
+    updated_by: UserReference | None = Field(
+        None, validation_alias=AliasChoices("updatedBy", "updated_by")
+    )
+    type: str | None = None
+    fields: list[ChangelogFieldChange] | None = None

--- a/mcp_tracker/tracker/proto/types/issues.py
+++ b/mcp_tracker/tracker/proto/types/issues.py
@@ -132,9 +132,19 @@ class ChecklistItem(BaseTrackerEntity):
     )
 
 
+class ChangelogFieldRef(BaseModel):
+    """Reference to a field in changelog"""
+    model_config = ConfigDict(extra="ignore")
+
+    id: str | None = None
+    display: str | None = None
+
+
 class ChangelogFieldChange(BaseModel):
     """Represents a single field change in changelog"""
-    field: str | None = Field(None, validation_alias=AliasChoices("field", "id"))
+    model_config = ConfigDict(extra="ignore")
+
+    field: ChangelogFieldRef | str | None = None
     from_value: str | dict | list | None = Field(
         None, validation_alias=AliasChoices("from", "from_value")
     )


### PR DESCRIPTION
## Summary

This PR adds a new MCP tool `issue_get_changelog` that allows retrieving the changelog (history of changes) for Yandex Tracker issues.

### Features

- **New models in `types/issues.py`:**
  - `ChangelogFieldChange` - represents a single field change (from → to)
  - `IssueChangelog` - represents a changelog entry with timestamp, author, type, and field changes

- **New method in `TrackerClient`:**
  - `issue_get_changelog(issue_id, per_page, field, change_type)` - calls `/v3/issues/{issue_id}/changelog` API

- **New MCP tool:**
  - `issue_get_changelog` with filtering options:
    - `per_page`: number of entries to return (default 50, max 100)
    - `field`: filter by specific field name (e.g., 'status', 'assignee', 'priority')
    - `change_type`: filter by change type (e.g., 'IssueCreated', 'IssueUpdated', 'IssueCommentAdded')

### API Reference

Yandex Tracker API endpoint: `GET /v3/issues/{issue_id}/changelog`

Documentation: https://yandex.ru/support/tracker/ru/concepts/issues/get-changelog

### Example Usage

```python
# Get all changelog entries for an issue
changelog = await issue_get_changelog(issue_id="PROJECT-123")

# Get only status changes
changelog = await issue_get_changelog(issue_id="PROJECT-123", field="status")

# Get only issue creation events
changelog = await issue_get_changelog(issue_id="PROJECT-123", change_type="IssueCreated")
```

## Test plan

- [x] Verify tool appears in MCP tool list
- [ ] Test basic changelog retrieval for an issue
- [ ] Test field filtering (status, assignee, priority)
- [ ] Test change_type filtering
- [ ] Verify error handling for non-existent issues (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)