### PR TITLE
feat: support passthrough Bearer token auth for reverse proxy deployments

### DIFF
--- a/mcp_tracker/mcp/utils.py
+++ b/mcp_tracker/mcp/utils.py
@@ -15,6 +15,16 @@ def get_yandex_auth(ctx: Context[Any, Any, Request]) -> YandexAuth:
     access_token = get_access_token()
     token = access_token.token if access_token else None
 
+    # Passthrough mode: when MCP OAuth is disabled (no access_token from MCP auth
+    # middleware), read the Yandex OAuth token directly from the Authorization
+    # header. This enables use behind a reverse proxy that injects per-user
+    # tokens (e.g. a gateway that resolves user identity and fetches their
+    # stored OAuth token from a secret store).
+    if token is None and ctx.request_context.request is not None:
+        auth_header = ctx.request_context.request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:].strip() or None
+
     auth = YandexAuth(token=token)
 
     if ctx.request_context.request is not None:


### PR DESCRIPTION
## Summary

When `OAUTH_ENABLED=false` and no static `TRACKER_TOKEN` matches the incoming request, read the Yandex OAuth token directly from the `Authorization: Bearer` header. This enables deployment behind a reverse proxy (e.g. a gateway that resolves user identity and injects their stored OAuth token per-request).

## Details

The change is ~10 lines in `mcp_tracker/mcp/utils.py`. The passthrough is only active when `get_access_token()` returns `None` (i.e. MCP OAuth middleware is not running), so it has zero effect on OAuth-enabled deployments.

### Use case

Running the MCP server behind an auth gateway that:
1. Authenticates the user via its own mechanism
2. Looks up their stored Yandex OAuth token
3. Injects it as `Authorization: Bearer <token>`
4. Proxies the request to the MCP server

The server picks up the token from the header and uses it for Tracker API calls.