### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Choose one of the following based on your Yandex organization type:
 You can find your organization ID in the Yandex Tracker URL or organization settings.
 
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aikts-yandex-tracker-mcp).
+
 ## MCP Client Configuration
 
 ### Installing extension in Claude Desktop


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/aikts-yandex-tracker-mcp).