### PR TITLE
feat(goals): add Goals (entities API) tools

### DIFF
--- a/mcp_tracker/mcp/context.py
+++ b/mcp_tracker/mcp/context.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
+from mcp_tracker.tracker.proto.goals import GoalsProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
 from mcp_tracker.tracker.proto.users import UsersProtocol
@@ -12,3 +13,4 @@ class AppContext:
     issues: IssueProtocol
     fields: GlobalDataProtocol
     users: UsersProtocol
+    goals: GoalsProtocol

--- a/mcp_tracker/mcp/params.py
+++ b/mcp_tracker/mcp/params.py
@@ -46,6 +46,14 @@ UserID = Annotated[
     ),
 ]
 
+GoalID = Annotated[
+    str,
+    Field(
+        description="Goal entity identifier (24-character hex string returned by goal_create / goals_search, "
+        "e.g., '69f1f551a5a4a076a93df775')."
+    ),
+]
+
 
 YTQuery = Annotated[
     str,

--- a/mcp_tracker/mcp/server.py
+++ b/mcp_tracker/mcp/server.py
@@ -20,6 +20,7 @@ from mcp_tracker.settings import Settings
 from mcp_tracker.tracker.caching.client import make_cached_protocols
 from mcp_tracker.tracker.custom.client import ServiceAccountSettings, TrackerClient
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
+from mcp_tracker.tracker.proto.goals import GoalsProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
 from mcp_tracker.tracker.proto.users import UsersProtocol
@@ -81,12 +82,14 @@ def make_tracker_lifespan(settings: Settings) -> Lifespan:
         issues: IssueProtocol = tracker
         global_data: GlobalDataProtocol = tracker
         users: UsersProtocol = tracker
+        goals: GoalsProtocol = tracker
         if settings.tools_cache_enabled:
             cache_collection = make_cached_protocols(settings.cache_kwargs())
             queues = cache_collection.queues(queues)
             issues = cache_collection.issues(issues)
             global_data = cache_collection.global_data(global_data)
             users = cache_collection.users(users)
+            goals = cache_collection.goals(goals)
 
         try:
             await tracker.prepare()
@@ -96,6 +99,7 @@ def make_tracker_lifespan(settings: Settings) -> Lifespan:
                 issues=issues,
                 fields=global_data,
                 users=users,
+                goals=goals,
             )
         finally:
             await tracker.close()

--- a/mcp_tracker/mcp/tools/__init__.py
+++ b/mcp_tracker/mcp/tools/__init__.py
@@ -6,6 +6,7 @@ This package organizes MCP tools by category:
 - issue_read.py: Issue read-only tools
 - issue_write.py: Issue write tools (conditional on read-only mode)
 - user.py: User-related tools (read-only)
+- goal.py: Goal entity tools (read + write)
 """
 
 from typing import Any
@@ -13,6 +14,10 @@ from typing import Any
 from mcp.server import FastMCP
 
 from mcp_tracker.mcp.tools.field import register_field_tools
+from mcp_tracker.mcp.tools.goal import (
+    register_goal_read_tools,
+    register_goal_write_tools,
+)
 from mcp_tracker.mcp.tools.issue_read import register_issue_read_tools
 from mcp_tracker.mcp.tools.issue_write import register_issue_write_tools
 from mcp_tracker.mcp.tools.queue import register_queue_tools
@@ -33,10 +38,12 @@ def register_all_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
     register_field_tools(settings, mcp)
     register_issue_read_tools(settings, mcp)
     register_user_tools(settings, mcp)
+    register_goal_read_tools(settings, mcp)
 
     # Only register write tools if not in read-only mode
     if not settings.tracker_read_only:
         register_issue_write_tools(settings, mcp)
+        register_goal_write_tools(settings, mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/mcp_tracker/mcp/tools/goal.py
+++ b/mcp_tracker/mcp/tools/goal.py
@@ -1,0 +1,266 @@
+"""Goal-entity MCP tools (read + write).
+
+Goals are part of the Yandex Tracker unified entities API
+(`/v3/entities/goal/...`). They are not regular issues — they live in their own
+namespace alongside projects and portfolios. See
+https://yandex.ru/support/tracker/ru/concepts/entities/about-entities
+
+Field reference (all optional unless noted, accepted in `fields` payload of
+create/update):
+- summary (str, required on create) — name
+- description (str)
+- end (str `YYYY-MM-DD`) — deadline
+- entityStatus (str) — workflow status (`draft`, `achieved`, `cancelled`, ...)
+- lead (str login or {id}) — responsible person
+- teamUsers / clients / followers (lists of user refs)
+- tags (list[str])
+- parentEntity ({id, entityType}) — parent goal/project/portfolio
+- teamAccess (bool)
+- keyResultItems / metricItems — key results and metrics
+"""
+
+from typing import Annotated, Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp import Context
+from mcp.types import ToolAnnotations
+from pydantic import Field
+from starlette.requests import Request
+
+from mcp_tracker.mcp.context import AppContext
+from mcp_tracker.mcp.params import PageParam, PerPageParam
+from mcp_tracker.mcp.utils import get_yandex_auth
+from mcp_tracker.settings import Settings
+from mcp_tracker.tracker.proto.types.goals import Goal
+
+
+def register_goal_read_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
+    """Register read-only goal tools."""
+
+    @mcp.tool(
+        title="Get Goal",
+        description=(
+            "Get a single Yandex Tracker goal entity by its id. "
+            "By default the API returns only meta fields (id, version, entityType, timestamps); "
+            "pass `fields` to receive editable attributes such as summary, description, end (deadline), "
+            "entityStatus, lead, teamUsers, clients, followers, tags, parentEntity, teamAccess."
+        ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def goal_get(
+        ctx: Context[Any, AppContext, Request],
+        goal_id: Annotated[
+            str,
+            Field(
+                description="Goal entity ID (24-char hex string), e.g., '69f1f551a5a4a076a93df775'."
+            ),
+        ],
+        fields: Annotated[
+            list[str] | None,
+            Field(
+                description="List of attribute names to include. Common: summary, description, end, "
+                "entityStatus, lead, teamUsers, clients, followers, tags, parentEntity, teamAccess, "
+                "keyResultItems, metricItems. Pass None to get only meta fields."
+            ),
+        ] = None,
+    ) -> Goal:
+        return await ctx.request_context.lifespan_context.goals.goal_get(
+            goal_id,
+            fields=fields,
+            auth=get_yandex_auth(ctx),
+        )
+
+    @mcp.tool(
+        title="Search Goals",
+        description=(
+            "Search Yandex Tracker goals via POST /v3/entities/goal/_search. "
+            "Returns a list of goal entities. Use `input` for free-text search, "
+            "or `filter` to pass a structured filter object (e.g., {'createdBy': 'login'}). "
+            "Pass `fields` to populate attributes in the result."
+        ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def goals_search(
+        ctx: Context[Any, AppContext, Request],
+        input: Annotated[
+            str | None,
+            Field(description="Free-text search query."),
+        ] = None,
+        filter: Annotated[
+            dict[str, Any] | None,
+            Field(description="Structured filter object passed through to the API."),
+        ] = None,
+        order_by: Annotated[
+            str | None,
+            Field(description="Field name to sort by (e.g., 'createdAt')."),
+        ] = None,
+        order_asc: Annotated[
+            bool | None,
+            Field(description="Sort direction. True = ASC, False = DESC."),
+        ] = None,
+        root_only: Annotated[
+            bool | None,
+            Field(description="If True — only root goals (no parent)."),
+        ] = None,
+        page: PageParam = 1,
+        per_page: PerPageParam = 50,
+        fields: Annotated[
+            list[str] | None,
+            Field(
+                description="Attribute names to include in each hit (e.g., ['summary','end','entityStatus','lead'])."
+            ),
+        ] = None,
+    ) -> list[Goal]:
+        return await ctx.request_context.lifespan_context.goals.goals_search(
+            input=input,
+            filter=filter,
+            order_by=order_by,
+            order_asc=order_asc,
+            root_only=root_only,
+            per_page=per_page,
+            page=page,
+            fields=fields,
+            auth=get_yandex_auth(ctx),
+        )
+
+
+def register_goal_write_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
+    """Register write goal tools (create/update/delete)."""
+
+    @mcp.tool(
+        title="Create Goal",
+        description=(
+            "Create a new goal entity in Yandex Tracker. "
+            "Minimum required field is `summary`. Common optional fields: "
+            "description, end (YYYY-MM-DD deadline), entityStatus, lead (user login or {id}), "
+            "teamUsers, clients, followers, tags, parentEntity, teamAccess. "
+            "Returns the created goal with id and shortId."
+        ),
+    )
+    async def goal_create(
+        ctx: Context[Any, AppContext, Request],
+        summary: Annotated[
+            str,
+            Field(description="Goal name (required)."),
+        ],
+        description: Annotated[
+            str | None,
+            Field(description="Goal description (Markdown supported)."),
+        ] = None,
+        end: Annotated[
+            str | None,
+            Field(description="Deadline date in 'YYYY-MM-DD' format."),
+        ] = None,
+        entity_status: Annotated[
+            str | None,
+            Field(
+                description="Workflow status, e.g., 'draft', 'achieved', 'cancelled'. "
+                "Defaults to 'draft' if omitted."
+            ),
+        ] = None,
+        lead: Annotated[
+            str | None,
+            Field(
+                description="Responsible person — user login or UID. Defaults to the authenticated user."
+            ),
+        ] = None,
+        tags: Annotated[
+            list[str] | None,
+            Field(description="List of tag strings."),
+        ] = None,
+        parent_entity_id: Annotated[
+            str | None,
+            Field(
+                description="Parent entity id (another goal/project/portfolio). "
+                "Pair with parent_entity_type."
+            ),
+        ] = None,
+        parent_entity_type: Annotated[
+            str | None,
+            Field(
+                description="Parent entity type: 'goal', 'project', or 'portfolio'."
+            ),
+        ] = None,
+        extra_fields: Annotated[
+            dict[str, Any] | None,
+            Field(
+                description="Additional fields to merge into the request payload. "
+                "Use this to set teamUsers, clients, followers, teamAccess, keyResultItems, metricItems, etc."
+            ),
+        ] = None,
+    ) -> Goal:
+        fields: dict[str, Any] = {"summary": summary}
+        if description is not None:
+            fields["description"] = description
+        if end is not None:
+            fields["end"] = end
+        if entity_status is not None:
+            fields["entityStatus"] = entity_status
+        if lead is not None:
+            fields["lead"] = lead
+        if tags is not None:
+            fields["tags"] = tags
+        if parent_entity_id is not None:
+            parent: dict[str, Any] = {"id": parent_entity_id}
+            if parent_entity_type is not None:
+                parent["entityType"] = parent_entity_type
+            fields["parentEntity"] = parent
+        if extra_fields:
+            for k, v in extra_fields.items():
+                fields.setdefault(k, v)
+
+        return await ctx.request_context.lifespan_context.goals.goal_create(
+            fields=fields,
+            auth=get_yandex_auth(ctx),
+        )
+
+    @mcp.tool(
+        title="Update Goal",
+        description=(
+            "Update an existing goal via PATCH /v3/entities/goal/{id}. "
+            "Pass only the fields you want to change. "
+            "NB: if any single field value is rejected, the whole patch is rolled back (HTTP 422)."
+        ),
+    )
+    async def goal_update(
+        ctx: Context[Any, AppContext, Request],
+        goal_id: Annotated[
+            str,
+            Field(description="Goal entity ID (24-char hex string)."),
+        ],
+        fields: Annotated[
+            dict[str, Any],
+            Field(
+                description="Object of fields to update. Example: "
+                "{'summary': 'New name', 'end': '2026-12-31', 'entityStatus': 'achieved'}."
+            ),
+        ],
+        version: Annotated[
+            int | None,
+            Field(
+                description="Optimistic-lock version. If provided and stale, the API returns 409."
+            ),
+        ] = None,
+    ) -> Goal:
+        return await ctx.request_context.lifespan_context.goals.goal_update(
+            goal_id,
+            fields=fields,
+            version=version,
+            auth=get_yandex_auth(ctx),
+        )
+
+    @mcp.tool(
+        title="Delete Goal",
+        description="Delete a goal entity. Returns nothing (HTTP 204).",
+    )
+    async def goal_delete(
+        ctx: Context[Any, AppContext, Request],
+        goal_id: Annotated[
+            str,
+            Field(description="Goal entity ID (24-char hex string)."),
+        ],
+    ) -> None:
+        await ctx.request_context.lifespan_context.goals.goal_delete(
+            goal_id,
+            auth=get_yandex_auth(ctx),
+        )

--- a/mcp_tracker/mcp/tools/goal.py
+++ b/mcp_tracker/mcp/tools/goal.py
@@ -10,7 +10,12 @@ create/update):
 - summary (str, required on create) — name
 - description (str)
 - end (str `YYYY-MM-DD`) — deadline
-- entityStatus (str) — workflow status (`draft`, `achieved`, `cancelled`, ...)
+- entityStatus (str) — workflow status. Full enum (snake_case):
+  `draft` (Новая), `according_to_plan` (По плану), `at_risk` (Есть риски),
+  `blocked` (Заблокирована), `achieved` (Достигнута),
+  `partially_achieved` (Частично достигнута), `not_achieved` (Не достигнута),
+  `exceeded` (Превышена), `cancelled` (Отменена).
+  See https://yandex.ru/support/tracker/ru/concepts/entities/about-entities
 - lead (str login or {id}) — responsible person
 - teamUsers / clients / followers (lists of user refs)
 - tags (list[str])
@@ -154,7 +159,9 @@ def register_goal_write_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
         entity_status: Annotated[
             str | None,
             Field(
-                description="Workflow status, e.g., 'draft', 'achieved', 'cancelled'. "
+                description="Workflow status (snake_case). One of: 'draft', "
+                "'according_to_plan', 'at_risk', 'blocked', 'achieved', "
+                "'partially_achieved', 'not_achieved', 'exceeded', 'cancelled'. "
                 "Defaults to 'draft' if omitted."
             ),
         ] = None,
@@ -232,7 +239,9 @@ def register_goal_write_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
             dict[str, Any],
             Field(
                 description="Object of fields to update. Example: "
-                "{'summary': 'New name', 'end': '2026-12-31', 'entityStatus': 'achieved'}."
+                "{'summary': 'New name', 'end': '2026-12-31', 'entityStatus': 'according_to_plan'}. "
+                "entityStatus enum (snake_case): draft, according_to_plan, at_risk, blocked, "
+                "achieved, partially_achieved, not_achieved, exceeded, cancelled."
             ),
         ],
         version: Annotated[

--- a/mcp_tracker/tracker/caching/client.py
+++ b/mcp_tracker/tracker/caching/client.py
@@ -6,9 +6,11 @@ from aiocache import cached
 
 from mcp_tracker.tracker.proto.common import YandexAuth
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocolWrap
+from mcp_tracker.tracker.proto.goals import GoalsProtocolWrap
 from mcp_tracker.tracker.proto.issues import IssueProtocolWrap
 from mcp_tracker.tracker.proto.queues import QueuesProtocolWrap
 from mcp_tracker.tracker.proto.types.fields import GlobalField, LocalField
+from mcp_tracker.tracker.proto.types.goals import Goal
 from mcp_tracker.tracker.proto.types.inputs import (
     IssueUpdateFollower,
     IssueUpdateParent,
@@ -45,6 +47,7 @@ class CacheCollection:
     issues: type[IssueProtocolWrap]
     global_data: type[GlobalDataProtocolWrap]
     users: type[UsersProtocolWrap]
+    goals: type[GoalsProtocolWrap]
 
 
 def make_cached_protocols(
@@ -408,9 +411,50 @@ def make_cached_protocols(
         async def user_get_current(self, *, auth: YandexAuth | None = None) -> User:
             return await self._original.user_get_current(auth=auth)
 
+    class CachingGoalsProtocol(GoalsProtocolWrap):
+        @cached(**cache_config)
+        async def goal_get(
+            self,
+            goal_id: str,
+            *,
+            fields: list[str] | None = None,
+            auth: YandexAuth | None = None,
+        ) -> Goal:
+            return await self._original.goal_get(goal_id, fields=fields, auth=auth)
+
+        @cached(**cache_config)
+        async def goals_search(
+            self,
+            *,
+            input: str | None = None,
+            filter: dict[str, Any] | None = None,
+            order_by: str | None = None,
+            order_asc: bool | None = None,
+            root_only: bool | None = None,
+            per_page: int = 50,
+            page: int = 1,
+            fields: list[str] | None = None,
+            auth: YandexAuth | None = None,
+        ) -> list[Goal]:
+            return await self._original.goals_search(
+                input=input,
+                filter=filter,
+                order_by=order_by,
+                order_asc=order_asc,
+                root_only=root_only,
+                per_page=per_page,
+                page=page,
+                fields=fields,
+                auth=auth,
+            )
+
+        # Write methods are not cached and bypass to the wrapped protocol via
+        # the inherited GoalsProtocolWrap implementations.
+
     return CacheCollection(
         queues=CachingQueuesProtocol,
         issues=CachingIssuesProtocol,
         global_data=CachingGlobalDataProtocol,
         users=CachingUsersProtocol,
+        goals=CachingGoalsProtocol,
     )

--- a/mcp_tracker/tracker/custom/client.py
+++ b/mcp_tracker/tracker/custom/client.py
@@ -14,12 +14,14 @@ from pydantic import BaseModel, RootModel
 from yandex.cloud.iam.v1.iam_token_service_pb2 import CreateIamTokenRequest
 from yandex.cloud.iam.v1.iam_token_service_pb2_grpc import IamTokenServiceStub
 
-from mcp_tracker.tracker.custom.errors import IssueNotFound
+from mcp_tracker.tracker.custom.errors import GoalNotFound, IssueNotFound
 from mcp_tracker.tracker.proto.common import YandexAuth
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
+from mcp_tracker.tracker.proto.goals import GoalsProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
 from mcp_tracker.tracker.proto.types.fields import GlobalField, LocalField
+from mcp_tracker.tracker.proto.types.goals import Goal
 from mcp_tracker.tracker.proto.types.inputs import (
     IssueUpdateFollower,
     IssueUpdateParent,
@@ -66,6 +68,7 @@ PriorityList = RootModel[list[Priority]]
 ResolutionList = RootModel[list[Resolution]]
 UserList = RootModel[list[User]]
 IssueTransitionList = RootModel[list[IssueTransition]]
+GoalList = RootModel[list[Goal]]
 
 
 logger = logging.getLogger(__name__)
@@ -175,7 +178,9 @@ class ServiceAccountStore:
         return IAMTokenInfo(token=iam_token.iam_token)
 
 
-class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProtocol):
+class TrackerClient(
+    QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProtocol, GoalsProtocol
+):
     def __init__(
         self,
         *,
@@ -862,3 +867,119 @@ class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProt
                 raise IssueNotFound(issue_id)
             response.raise_for_status()
             return Issue.model_validate_json(await response.read())
+
+    # ---- Goals (entities API) ----
+
+    async def goal_get(
+        self,
+        goal_id: str,
+        *,
+        fields: list[str] | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Goal:
+        params: dict[str, str] = {}
+        if fields:
+            params["fields"] = ",".join(fields)
+        async with self._session.get(
+            f"v3/entities/goal/{goal_id}",
+            headers=await self._build_headers(auth),
+            params=params if params else None,
+        ) as response:
+            if response.status == 404:
+                raise GoalNotFound(goal_id)
+            response.raise_for_status()
+            return Goal.model_validate_json(await response.read())
+
+    async def goal_create(
+        self,
+        *,
+        fields: dict[str, Any],
+        auth: YandexAuth | None = None,
+    ) -> Goal:
+        body: dict[str, Any] = {"fields": fields}
+        async with self._session.post(
+            "v3/entities/goal",
+            headers=await self._build_headers(auth),
+            json=body,
+        ) as response:
+            response.raise_for_status()
+            return Goal.model_validate_json(await response.read())
+
+    async def goal_update(
+        self,
+        goal_id: str,
+        *,
+        fields: dict[str, Any],
+        version: int | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Goal:
+        body: dict[str, Any] = {"fields": fields}
+        params: dict[str, int] = {}
+        if version is not None:
+            params["version"] = version
+        async with self._session.patch(
+            f"v3/entities/goal/{goal_id}",
+            headers=await self._build_headers(auth),
+            json=body,
+            params=params if params else None,
+        ) as response:
+            if response.status == 404:
+                raise GoalNotFound(goal_id)
+            response.raise_for_status()
+            return Goal.model_validate_json(await response.read())
+
+    async def goal_delete(
+        self,
+        goal_id: str,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> None:
+        async with self._session.delete(
+            f"v3/entities/goal/{goal_id}",
+            headers=await self._build_headers(auth),
+        ) as response:
+            if response.status == 404:
+                raise GoalNotFound(goal_id)
+            response.raise_for_status()
+            return None
+
+    async def goals_search(
+        self,
+        *,
+        input: str | None = None,
+        filter: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        order_asc: bool | None = None,
+        root_only: bool | None = None,
+        per_page: int = 50,
+        page: int = 1,
+        fields: list[str] | None = None,
+        auth: YandexAuth | None = None,
+    ) -> list[Goal]:
+        params: dict[str, str | int] = {"perPage": per_page, "page": page}
+        if fields:
+            params["fields"] = ",".join(fields)
+
+        body: dict[str, Any] = {}
+        if input is not None:
+            body["input"] = input
+        if filter is not None:
+            body["filter"] = filter
+        if order_by is not None:
+            body["orderBy"] = order_by
+        if order_asc is not None:
+            body["orderAsc"] = order_asc
+        if root_only is not None:
+            body["rootOnly"] = root_only
+
+        async with self._session.post(
+            "v3/entities/goal/_search",
+            headers=await self._build_headers(auth),
+            json=body,
+            params=params,
+        ) as response:
+            response.raise_for_status()
+            payload = await response.json()
+            # API returns {"hits": N, "pages": M, "values": [...]} OR a bare list
+            values = payload.get("values", []) if isinstance(payload, dict) else payload
+            return GoalList.model_validate(values).root

--- a/mcp_tracker/tracker/custom/errors.py
+++ b/mcp_tracker/tracker/custom/errors.py
@@ -6,3 +6,9 @@ class IssueNotFound(YandexTrackerError):
     def __init__(self, issue_id: str):
         super().__init__(f"Issue with ID '{issue_id}' not found.")
         self.issue_id = issue_id
+
+
+class GoalNotFound(YandexTrackerError):
+    def __init__(self, goal_id: str):
+        super().__init__(f"Goal with ID '{goal_id}' not found.")
+        self.goal_id = goal_id

--- a/mcp_tracker/tracker/proto/goals.py
+++ b/mcp_tracker/tracker/proto/goals.py
@@ -1,0 +1,121 @@
+"""Protocol for Yandex Tracker Goal entity operations."""
+
+from typing import Any, Protocol, runtime_checkable
+
+from .common import YandexAuth
+from .types.goals import Goal
+
+
+@runtime_checkable
+class GoalsProtocol(Protocol):
+    async def goal_get(
+        self,
+        goal_id: str,
+        *,
+        fields: list[str] | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Goal: ...
+
+    async def goal_create(
+        self,
+        *,
+        fields: dict[str, Any],
+        auth: YandexAuth | None = None,
+    ) -> Goal: ...
+
+    async def goal_update(
+        self,
+        goal_id: str,
+        *,
+        fields: dict[str, Any],
+        version: int | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Goal: ...
+
+    async def goal_delete(
+        self,
+        goal_id: str,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> None: ...
+
+    async def goals_search(
+        self,
+        *,
+        input: str | None = None,
+        filter: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        order_asc: bool | None = None,
+        root_only: bool | None = None,
+        per_page: int = 50,
+        page: int = 1,
+        fields: list[str] | None = None,
+        auth: YandexAuth | None = None,
+    ) -> list[Goal]: ...
+
+
+class GoalsProtocolWrap(GoalsProtocol):
+    def __init__(self, original: GoalsProtocol):
+        self._original = original
+
+    async def goal_get(
+        self,
+        goal_id: str,
+        *,
+        fields: list[str] | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Goal:
+        return await self._original.goal_get(goal_id, fields=fields, auth=auth)
+
+    async def goal_create(
+        self,
+        *,
+        fields: dict[str, Any],
+        auth: YandexAuth | None = None,
+    ) -> Goal:
+        return await self._original.goal_create(fields=fields, auth=auth)
+
+    async def goal_update(
+        self,
+        goal_id: str,
+        *,
+        fields: dict[str, Any],
+        version: int | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Goal:
+        return await self._original.goal_update(
+            goal_id, fields=fields, version=version, auth=auth
+        )
+
+    async def goal_delete(
+        self,
+        goal_id: str,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> None:
+        return await self._original.goal_delete(goal_id, auth=auth)
+
+    async def goals_search(
+        self,
+        *,
+        input: str | None = None,
+        filter: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        order_asc: bool | None = None,
+        root_only: bool | None = None,
+        per_page: int = 50,
+        page: int = 1,
+        fields: list[str] | None = None,
+        auth: YandexAuth | None = None,
+    ) -> list[Goal]:
+        return await self._original.goals_search(
+            input=input,
+            filter=filter,
+            order_by=order_by,
+            order_asc=order_asc,
+            root_only=root_only,
+            per_page=per_page,
+            page=page,
+            fields=fields,
+            auth=auth,
+        )

--- a/mcp_tracker/tracker/proto/types/goals.py
+++ b/mcp_tracker/tracker/proto/types/goals.py
@@ -106,7 +106,13 @@ GoalEntityStatus = Enum(  # type: ignore[misc]  # ty: ignore[unused-ignore-comme
     "GoalEntityStatus",
     {
         "draft": "draft",
+        "according_to_plan": "according_to_plan",
+        "at_risk": "at_risk",
+        "blocked": "blocked",
         "achieved": "achieved",
+        "partially_achieved": "partially_achieved",
+        "not_achieved": "not_achieved",
+        "exceeded": "exceeded",
         "cancelled": "cancelled",
     },
 )

--- a/mcp_tracker/tracker/proto/types/goals.py
+++ b/mcp_tracker/tracker/proto/types/goals.py
@@ -1,0 +1,129 @@
+"""Pydantic models for Yandex Tracker Goal entities.
+
+Goals are part of the unified `/v3/entities/{type}` API alongside projects and
+portfolios. This module models only the `goal` entity type. The shape mirrors
+what the API returns: top-level meta fields (`id`, `version`, `entityType`,
+timestamps, `createdBy`) plus a nested `fields` object that holds editable
+attributes (`summary`, `description`, `end` deadline, `entityStatus`, `lead`,
+team/clients/followers, tags, parent, etc.).
+"""
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field
+
+from mcp_tracker.tracker.proto.types.base import BaseTrackerEntity, NoneExcludedField
+
+
+class GoalUserRef(BaseTrackerEntity):
+    """User reference embedded inside Goal (lead/teamUsers/clients/followers)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    self: str | None = NoneExcludedField
+    id: str | None = NoneExcludedField
+    display: str | None = NoneExcludedField
+    cloudUid: str | None = NoneExcludedField
+    passportUid: int | None = NoneExcludedField
+
+
+class GoalParentEntityRef(BaseTrackerEntity):
+    """Reference to a parent entity (another goal/project/portfolio)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    self: str | None = NoneExcludedField
+    id: str | None = NoneExcludedField
+    entityType: str | None = NoneExcludedField
+    display: str | None = NoneExcludedField
+
+
+class GoalFields(BaseTrackerEntity):
+    """Editable attributes of a Goal returned inside the `fields` envelope.
+
+    All fields are optional because the API only returns those requested via
+    the `?fields=` query parameter. The Tracker UI exposes more attributes
+    (key results, metrics, weight, etc.) — those that can be set via REST are
+    listed in the official documentation:
+    https://yandex.ru/support/tracker/ru/concepts/entities/about-entities
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    summary: str | None = NoneExcludedField
+    description: str | None = NoneExcludedField
+    end: date | None = NoneExcludedField
+    entityStatus: str | None = NoneExcludedField
+    lead: GoalUserRef | None = NoneExcludedField
+    teamUsers: list[GoalUserRef] | None = NoneExcludedField
+    clients: list[GoalUserRef] | None = NoneExcludedField
+    followers: list[GoalUserRef] | None = NoneExcludedField
+    tags: list[str] | None = NoneExcludedField
+    parentEntity: GoalParentEntityRef | None = NoneExcludedField
+    teamAccess: bool | None = NoneExcludedField
+    keyResultItems: list[Any] | None = NoneExcludedField
+    metricItems: list[Any] | None = NoneExcludedField
+    lastCommentUpdatedAt: datetime | None = NoneExcludedField
+
+
+class Goal(BaseTrackerEntity):
+    """A Tracker Goal entity (`/v3/entities/goal/{id}`)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    self: str | None = NoneExcludedField
+    id: str | None = NoneExcludedField
+    version: int | None = NoneExcludedField
+    shortId: int | None = NoneExcludedField
+    entityType: Literal["goal"] | None = NoneExcludedField
+    createdBy: GoalUserRef | None = NoneExcludedField
+    createdAt: datetime | None = NoneExcludedField
+    updatedAt: datetime | None = NoneExcludedField
+    fields: GoalFields | None = NoneExcludedField
+
+
+GoalFieldName = Literal[
+    "summary",
+    "description",
+    "end",
+    "entityStatus",
+    "lead",
+    "teamUsers",
+    "clients",
+    "followers",
+    "tags",
+    "parentEntity",
+    "teamAccess",
+    "keyResultItems",
+    "metricItems",
+    "lastCommentUpdatedAt",
+]
+
+
+GoalEntityStatus = Enum(  # type: ignore[misc]  # ty: ignore[unused-ignore-comment]
+    "GoalEntityStatus",
+    {
+        "draft": "draft",
+        "achieved": "achieved",
+        "cancelled": "cancelled",
+    },
+)
+
+
+class GoalSearchRequest(BaseTrackerEntity):
+    """Body of `POST /v3/entities/goal/_search`.
+
+    The endpoint accepts a free-form filter object plus an optional sort spec.
+    Pass-through `extra="allow"` keeps the wrapper forward-compatible with
+    additional filter fields that the API may add later.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    input: str | None = Field(default=None, description="Free-text search query")
+    filter: dict[str, Any] | None = Field(default=None, description="Filter object")
+    orderBy: str | None = NoneExcludedField
+    orderAsc: bool | None = NoneExcludedField
+    rootOnly: bool | None = NoneExcludedField


### PR DESCRIPTION
## Summary

Adds support for **Yandex Tracker Goals** (the unified `/v3/entities/goal/*` API), which currently isn't covered by the MCP server. Goals are a separate entity type from issues — they represent OKR-style objectives created via `tracker.yandex.ru/createGoal` — and are part of the same entities API as projects and portfolios.

Five new MCP tools, mirroring the conventions used by the existing `queue` / `issue` modules:

**Read-only** (always registered):
- `goal_get(goal_id, fields=None)` — `GET /v3/entities/goal/{id}`
- `goals_search(input, filter, ...)` — `POST /v3/entities/goal/_search`

**Write** (gated by `tracker_read_only`):
- `goal_create(summary, description, end, entity_status, lead, tags, parent_entity_id, parent_entity_type, extra_fields)` — `POST /v3/entities/goal`
- `goal_update(goal_id, fields, version)` — `PATCH /v3/entities/goal/{id}`
- `goal_delete(goal_id)` — `DELETE /v3/entities/goal/{id}`

## Architecture

Symmetric to existing modules:

- `tracker/proto/types/goals.py` — pydantic models (`Goal`, `GoalFields`, `GoalUserRef`, `GoalParentEntityRef`, `GoalSearchRequest`)
- `tracker/proto/goals.py` — `GoalsProtocol` + `GoalsProtocolWrap`
- `tracker/custom/client.py` — `TrackerClient` now also implements `GoalsProtocol`; client methods + `GoalList` RootModel
- `tracker/custom/errors.py` — `GoalNotFound`
- `tracker/caching/client.py` — `CachingGoalsProtocol` (read methods cached, writes pass-through); `CacheCollection.goals`
- `mcp/context.py` — `AppContext.goals: GoalsProtocol`
- `mcp/server.py` — wires goals into lifespan; respects `tools_cache_enabled`
- `mcp/tools/goal.py` — `register_goal_read_tools` + `register_goal_write_tools`
- `mcp/tools/__init__.py` — registers both
- `mcp/params.py` — adds `GoalID` annotation

## API quirks captured in code/docstrings

- **Deadline field is `end`** (`YYYY-MM-DD`), **not** `dueDate`/`deadline` — these are the obvious guesses but they error with `Field [dueDate] was not found`.
- **`GET` returns only meta** (`id`, `version`, `entityType`, timestamps, `createdBy`) when called bare. Pass `fields` (CSV-encoded) to populate `summary`, `description`, `end`, `entityStatus`, `lead`, etc.
- **`PATCH` is all-or-nothing**: if any single field value is rejected (e.g., bad `entityStatus` enum), the whole request returns 422 and *no* fields are updated.
- **`entityStatus`** appears to accept a fixed enum — verified `draft` / `achieved` / `cancelled` work; others returned `Значение X для поля Статус недопустимо`.
- **Search** response shape: `{ "hits": N, "pages": M, "values": [...] }` — client unwraps `values`.

## Test plan

- [x] Imports / module load — `python -c 'from mcp_tracker.mcp.tools.goal import ...'` ✅
- [x] `ruff check mcp_tracker/` — clean ✅
- [x] Smoke-tested every endpoint manually against `api.tracker.yandex.net` with an OAuth token (create / get / update / search / delete — all return expected shapes)
- [ ] Add unit tests under `tests/` (happy to follow up if reviewers prefer test coverage in the same PR)

## Notes

- Field reference taken from the official docs: https://yandex.ru/support/tracker/ru/concepts/entities/about-entities
- Same auth model as the rest of the server (`OAuth` / IAM / SA / per-request override).
- No new dependencies.