### PR TITLE
Implementing queue component management. Create/Get/Update/Delete

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -60,6 +60,18 @@
       "description": "Get detailed metadata about a specific queue"
     },
     {
+      "name": "component_create",
+      "description": "Create a new component in a Yandex Tracker queue"
+    },
+    {
+      "name": "component_update",
+      "description": "Update an existing component in Yandex Tracker"
+    },
+    {
+      "name": "component_delete",
+      "description": "Delete a component from Yandex Tracker"
+    },
+    {
       "name": "users_get_all",
       "description": "Get information about user accounts registered in the organization"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -60,6 +60,10 @@
       "description": "Get detailed metadata about a specific queue"
     },
     {
+      "name": "components_get_all",
+      "description": "Get all components in the Yandex Tracker organization"
+    },
+    {
       "name": "component_get",
       "description": "Get a component from Yandex Tracker by its ID"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -60,6 +60,10 @@
       "description": "Get detailed metadata about a specific queue"
     },
     {
+      "name": "component_get",
+      "description": "Get a component from Yandex Tracker by its ID"
+    },
+    {
       "name": "component_create",
       "description": "Create a new component in a Yandex Tracker queue"
     },

--- a/mcp_tracker/mcp/context.py
+++ b/mcp_tracker/mcp/context.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
@@ -12,3 +13,4 @@ class AppContext:
     issues: IssueProtocol
     fields: GlobalDataProtocol
     users: UsersProtocol
+    components: ComponentsProtocol

--- a/mcp_tracker/mcp/server.py
+++ b/mcp_tracker/mcp/server.py
@@ -19,6 +19,7 @@ from mcp_tracker.mcp.tools import register_all_tools
 from mcp_tracker.settings import Settings
 from mcp_tracker.tracker.caching.client import make_cached_protocols
 from mcp_tracker.tracker.custom.client import ServiceAccountSettings, TrackerClient
+from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
@@ -81,12 +82,14 @@ def make_tracker_lifespan(settings: Settings) -> Lifespan:
         issues: IssueProtocol = tracker
         global_data: GlobalDataProtocol = tracker
         users: UsersProtocol = tracker
+        components: ComponentsProtocol = tracker
         if settings.tools_cache_enabled:
             cache_collection = make_cached_protocols(settings.cache_kwargs())
             queues = cache_collection.queues(queues)
             issues = cache_collection.issues(issues)
             global_data = cache_collection.global_data(global_data)
             users = cache_collection.users(users)
+            components = cache_collection.components(components)
 
         try:
             await tracker.prepare()
@@ -96,6 +99,7 @@ def make_tracker_lifespan(settings: Settings) -> Lifespan:
                 issues=issues,
                 fields=global_data,
                 users=users,
+                components=components,
             )
         finally:
             await tracker.close()

--- a/mcp_tracker/mcp/tools/__init__.py
+++ b/mcp_tracker/mcp/tools/__init__.py
@@ -6,6 +6,7 @@ This package organizes MCP tools by category:
 - field.py: Global field and metadata tools (read-only)
 - issue_read.py: Issue read-only tools
 - issue_write.py: Issue write tools (conditional on read-only mode)
+- components.py: Component write tools (conditional on read-only mode)
 - user.py: User-related tools (read-only)
 """
 
@@ -13,6 +14,7 @@ from typing import Any
 
 from mcp.server import FastMCP
 
+from mcp_tracker.mcp.tools.components import register_component_tools
 from mcp_tracker.mcp.tools.field import register_field_tools
 from mcp_tracker.mcp.tools.issue_read import register_issue_read_tools
 from mcp_tracker.mcp.tools.issue_write import register_issue_write_tools
@@ -40,6 +42,7 @@ def register_all_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
     if not settings.tracker_read_only:
         register_queue_write_tools(settings, mcp)
         register_issue_write_tools(settings, mcp)
+        register_component_tools(settings, mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/mcp_tracker/mcp/tools/__init__.py
+++ b/mcp_tracker/mcp/tools/__init__.py
@@ -6,7 +6,8 @@ This package organizes MCP tools by category:
 - field.py: Global field and metadata tools (read-only)
 - issue_read.py: Issue read-only tools
 - issue_write.py: Issue write tools (conditional on read-only mode)
-- components.py: Component write tools (conditional on read-only mode)
+- component_read.py: Component read-only tools
+- component_write.py: Component write tools (conditional on read-only mode)
 - user.py: User-related tools (read-only)
 """
 
@@ -14,7 +15,8 @@ from typing import Any
 
 from mcp.server import FastMCP
 
-from mcp_tracker.mcp.tools.components import register_component_tools
+from mcp_tracker.mcp.tools.component_read import register_component_read_tools
+from mcp_tracker.mcp.tools.component_write import register_component_write_tools
 from mcp_tracker.mcp.tools.field import register_field_tools
 from mcp_tracker.mcp.tools.issue_read import register_issue_read_tools
 from mcp_tracker.mcp.tools.issue_write import register_issue_write_tools
@@ -36,13 +38,14 @@ def register_all_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
     register_queue_tools(settings, mcp)
     register_field_tools(settings, mcp)
     register_issue_read_tools(settings, mcp)
+    register_component_read_tools(settings, mcp)
     register_user_tools(settings, mcp)
 
     # Only register write tools if not in read-only mode
     if not settings.tracker_read_only:
         register_queue_write_tools(settings, mcp)
         register_issue_write_tools(settings, mcp)
-        register_component_tools(settings, mcp)
+        register_component_write_tools(settings, mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/mcp_tracker/mcp/tools/_access.py
+++ b/mcp_tracker/mcp/tools/_access.py
@@ -26,6 +26,8 @@ def check_component_access(settings: Settings, component: Component) -> None:
 
     queue_key = component.queue.key if component.queue is not None else None
     if queue_key is None:
-        raise TrackerError(f"Component `{component.name}` queue is unknown; access denied.")
+        raise TrackerError(
+            f"Component `{component.name}` queue is unknown; access denied."
+        )
 
     check_queue_access(settings, queue_key)

--- a/mcp_tracker/mcp/tools/_access.py
+++ b/mcp_tracker/mcp/tools/_access.py
@@ -3,6 +3,7 @@
 from mcp_tracker.mcp.errors import TrackerError
 from mcp_tracker.settings import Settings
 from mcp_tracker.tracker.custom.errors import IssueNotFound
+from mcp_tracker.tracker.proto.types.components import Component
 
 
 def check_issue_access(settings: Settings, issue_id: str) -> None:
@@ -16,3 +17,15 @@ def check_queue_access(settings: Settings, queue_id: str) -> None:
     """Check if access to the queue is allowed based on queue restrictions."""
     if settings.tracker_limit_queues and queue_id not in settings.tracker_limit_queues:
         raise TrackerError(f"Queue `{queue_id}` not found or not allowed.")
+
+
+def check_component_access(settings: Settings, component: Component) -> None:
+    """Check if access to the component is allowed based on queue restrictions."""
+    if not settings.tracker_limit_queues:
+        return
+
+    queue_key = component.queue.key if component.queue is not None else None
+    if queue_key is None:
+        raise TrackerError(f"Component `{component.name}` queue is unknown; access denied.")
+
+    check_queue_access(settings, queue_key)

--- a/mcp_tracker/mcp/tools/component_read.py
+++ b/mcp_tracker/mcp/tools/component_read.py
@@ -8,6 +8,7 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from mcp_tracker.mcp.context import AppContext
+from mcp_tracker.mcp.tools._access import check_component_access
 from mcp_tracker.mcp.utils import get_yandex_auth
 from mcp_tracker.settings import Settings
 from mcp_tracker.tracker.proto.types.components import Component
@@ -28,7 +29,9 @@ def register_component_read_tools(settings: Settings, mcp: FastMCP[Any]) -> None
             Field(description="Component ID (integer)."),
         ],
     ) -> Component:
-        return await ctx.request_context.lifespan_context.components.component_get(
+        component = await ctx.request_context.lifespan_context.components.component_get(
             component_id,
             auth=get_yandex_auth(ctx),
         )
+        check_component_access(settings, component)
+        return component

--- a/mcp_tracker/mcp/tools/component_read.py
+++ b/mcp_tracker/mcp/tools/component_read.py
@@ -1,0 +1,34 @@
+"""Component read-only MCP tools."""
+
+from typing import Annotated, Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp import Context
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from mcp_tracker.mcp.context import AppContext
+from mcp_tracker.mcp.utils import get_yandex_auth
+from mcp_tracker.settings import Settings
+from mcp_tracker.tracker.proto.types.components import Component
+
+
+def register_component_read_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
+    """Register component read-only tools."""
+
+    @mcp.tool(
+        title="Get Component",
+        description="Get a component from Yandex Tracker by its ID.",
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def component_get(
+        ctx: Context[Any, AppContext],
+        component_id: Annotated[
+            int,
+            Field(description="Component ID (integer)."),
+        ],
+    ) -> Component:
+        return await ctx.request_context.lifespan_context.components.component_get(
+            component_id,
+            auth=get_yandex_auth(ctx),
+        )

--- a/mcp_tracker/mcp/tools/component_read.py
+++ b/mcp_tracker/mcp/tools/component_read.py
@@ -8,7 +8,8 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from mcp_tracker.mcp.context import AppContext
-from mcp_tracker.mcp.tools._access import check_component_access
+from mcp_tracker.mcp.params import PerPageParam, QueueID
+from mcp_tracker.mcp.tools._access import check_component_access, check_queue_access
 from mcp_tracker.mcp.utils import get_yandex_auth
 from mcp_tracker.settings import Settings
 from mcp_tracker.tracker.proto.types.components import Component
@@ -16,6 +17,71 @@ from mcp_tracker.tracker.proto.types.components import Component
 
 def register_component_read_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
     """Register component read-only tools."""
+
+    @mcp.tool(
+        title="Get All Components",
+        description="Get components in the Yandex Tracker organization. "
+        "Supports pagination; omit page to retrieve all pages. "
+        "Optionally filter by queue key.",
+        annotations=ToolAnnotations(readOnlyHint=True),
+    )
+    async def components_get_all(
+        ctx: Context[Any, AppContext],
+        queue_id: QueueID | None = None,
+        page: Annotated[
+            int | None,
+            Field(
+                description="Page number to return, default is None which means to retrieve all pages. "
+                "Specify page number to retrieve a specific page when context limit is reached.",
+                ge=1,
+            ),
+        ] = None,
+        per_page: PerPageParam = 50,
+    ) -> list[Component]:
+        if queue_id is not None:
+            check_queue_access(settings, queue_id)
+
+        result: list[Component] = []
+
+        fetch_all_pages = page is None
+        if fetch_all_pages:
+            page = 1
+
+        # At this point page is always an int
+        assert page is not None
+
+        components_client = ctx.request_context.lifespan_context.components
+        while True:
+            components = await components_client.components_list(
+                per_page=per_page,
+                page=page,
+                auth=get_yandex_auth(ctx),
+            )
+            if len(components) == 0:
+                break
+
+            result.extend(components)
+
+            if not fetch_all_pages:
+                break  # Only fetch the requested page
+            page += 1
+
+        if queue_id is not None:
+            result = [
+                component
+                for component in result
+                if component.queue is not None and component.queue.key == queue_id
+            ]
+
+        if settings.tracker_limit_queues:
+            allowed_queues = set(settings.tracker_limit_queues)
+            result = [
+                component
+                for component in result
+                if component.queue is not None and component.queue.key in allowed_queues
+            ]
+
+        return result
 
     @mcp.tool(
         title="Get Component",

--- a/mcp_tracker/mcp/tools/component_write.py
+++ b/mcp_tracker/mcp/tools/component_write.py
@@ -1,0 +1,108 @@
+"""Component write MCP tools (conditionally registered based on read-only mode)."""
+
+from typing import Annotated, Any
+
+from mcp.server import FastMCP
+from mcp.server.fastmcp import Context
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from mcp_tracker.mcp.context import AppContext
+from mcp_tracker.mcp.params import QueueID
+from mcp_tracker.mcp.tools._access import check_queue_access
+from mcp_tracker.mcp.utils import get_yandex_auth
+from mcp_tracker.settings import Settings
+from mcp_tracker.tracker.proto.types.components import Component
+
+
+def register_component_write_tools(settings: Settings, mcp: FastMCP[Any]) -> None:
+    """Register component write tools (not registered in read-only mode)."""
+
+    @mcp.tool(
+        title="Create Component",
+        description="Create a new component in a Yandex Tracker queue. "
+        "Components are used to categorize issues by service or module.",
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def component_create(
+        ctx: Context[Any, AppContext],
+        queue_id: QueueID,
+        name: Annotated[
+            str,
+            Field(description="Component name (e.g., 'Test', 'Monitoring')"),
+        ],
+        description: Annotated[
+            str | None,
+            Field(description="Optional component description"),
+        ] = None,
+        lead: Annotated[
+            str | None,
+            Field(
+                description="Login (string) of the user responsible for this component"
+            ),
+        ] = None,
+        assign_auto: Annotated[
+            bool | None,
+            Field(description="Automatically assign the component lead to issues"),
+        ] = None,
+    ) -> Component:
+        check_queue_access(settings, queue_id)
+        return await ctx.request_context.lifespan_context.components.component_create(
+            queue_id,
+            name=name,
+            description=description,
+            lead=lead,
+            assign_auto=assign_auto,
+            auth=get_yandex_auth(ctx),
+        )
+
+    @mcp.tool(
+        title="Update Component",
+        description="Update an existing component in Yandex Tracker.",
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def component_update(
+        ctx: Context[Any, AppContext],
+        component_id: Annotated[
+            int,
+            Field(description="Component ID (integer)."),
+        ],
+        name: Annotated[
+            str | None,
+            Field(description="New component name"),
+        ] = None,
+        description: Annotated[
+            str | None,
+            Field(description="New component description"),
+        ] = None,
+        lead: Annotated[
+            str | None,
+            Field(
+                description="Login (string) of the user responsible for this component"
+            ),
+        ] = None,
+    ) -> Component:
+        return await ctx.request_context.lifespan_context.components.component_update(
+            component_id,
+            name=name,
+            description=description,
+            lead=lead,
+            auth=get_yandex_auth(ctx),
+        )
+
+    @mcp.tool(
+        title="Delete Component",
+        description="Delete a component from Yandex Tracker.",
+        annotations=ToolAnnotations(readOnlyHint=False),
+    )
+    async def component_delete(
+        ctx: Context[Any, AppContext],
+        component_id: Annotated[
+            int,
+            Field(description="Component ID (integer)."),
+        ],
+    ) -> None:
+        await ctx.request_context.lifespan_context.components.component_delete(
+            component_id,
+            auth=get_yandex_auth(ctx),
+        )

--- a/mcp_tracker/mcp/tools/component_write.py
+++ b/mcp_tracker/mcp/tools/component_write.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from mcp_tracker.mcp.context import AppContext
 from mcp_tracker.mcp.params import QueueID
-from mcp_tracker.mcp.tools._access import check_queue_access
+from mcp_tracker.mcp.tools._access import check_component_access, check_queue_access
 from mcp_tracker.mcp.utils import get_yandex_auth
 from mcp_tracker.settings import Settings
 from mcp_tracker.tracker.proto.types.components import Component
@@ -82,7 +82,10 @@ def register_component_write_tools(settings: Settings, mcp: FastMCP[Any]) -> Non
             ),
         ] = None,
     ) -> Component:
-        return await ctx.request_context.lifespan_context.components.component_update(
+        components = ctx.request_context.lifespan_context.components
+        component = await components.component_get(component_id, auth=get_yandex_auth(ctx))
+        check_component_access(settings, component)
+        return await components.component_update(
             component_id,
             name=name,
             description=description,
@@ -102,7 +105,10 @@ def register_component_write_tools(settings: Settings, mcp: FastMCP[Any]) -> Non
             Field(description="Component ID (integer)."),
         ],
     ) -> None:
-        await ctx.request_context.lifespan_context.components.component_delete(
+        components = ctx.request_context.lifespan_context.components
+        component = await components.component_get(component_id, auth=get_yandex_auth(ctx))
+        check_component_access(settings, component)
+        await components.component_delete(
             component_id,
             auth=get_yandex_auth(ctx),
         )

--- a/mcp_tracker/mcp/tools/component_write.py
+++ b/mcp_tracker/mcp/tools/component_write.py
@@ -83,7 +83,9 @@ def register_component_write_tools(settings: Settings, mcp: FastMCP[Any]) -> Non
         ] = None,
     ) -> Component:
         components = ctx.request_context.lifespan_context.components
-        component = await components.component_get(component_id, auth=get_yandex_auth(ctx))
+        component = await components.component_get(
+            component_id, auth=get_yandex_auth(ctx)
+        )
         check_component_access(settings, component)
         return await components.component_update(
             component_id,
@@ -106,7 +108,9 @@ def register_component_write_tools(settings: Settings, mcp: FastMCP[Any]) -> Non
         ],
     ) -> None:
         components = ctx.request_context.lifespan_context.components
-        component = await components.component_get(component_id, auth=get_yandex_auth(ctx))
+        component = await components.component_get(
+            component_id, auth=get_yandex_auth(ctx)
+        )
         check_component_access(settings, component)
         await components.component_delete(
             component_id,

--- a/mcp_tracker/tracker/caching/client.py
+++ b/mcp_tracker/tracker/caching/client.py
@@ -500,6 +500,15 @@ def make_cached_protocols(
             return await self._original.user_get_current(auth=auth)
 
     class CachingComponentsProtocol(ComponentsProtocolWrap):
+        @cached(**cache_config)
+        async def component_get(
+            self,
+            component_id: int,
+            *,
+            auth: YandexAuth | None = None,
+        ) -> Component:
+            return await self._original.component_get(component_id, auth=auth)
+
         async def component_create(
             self,
             queue_id: str,

--- a/mcp_tracker/tracker/caching/client.py
+++ b/mcp_tracker/tracker/caching/client.py
@@ -506,12 +506,16 @@ def make_cached_protocols(
             *,
             name: str,
             description: str | None = None,
+            lead: str | None = None,
+            assign_auto: bool | None = None,
             auth: YandexAuth | None = None,
         ) -> Component:
             return await self._original.component_create(
                 queue_id,
                 name=name,
                 description=description,
+                lead=lead,
+                assign_auto=assign_auto,
                 auth=auth,
             )
 
@@ -521,12 +525,14 @@ def make_cached_protocols(
             *,
             name: str | None = None,
             description: str | None = None,
+            lead: str | None = None,
             auth: YandexAuth | None = None,
         ) -> Component:
             return await self._original.component_update(
                 component_id,
                 name=name,
                 description=description,
+                lead=lead,
                 auth=auth,
             )
 

--- a/mcp_tracker/tracker/caching/client.py
+++ b/mcp_tracker/tracker/caching/client.py
@@ -501,6 +501,18 @@ def make_cached_protocols(
 
     class CachingComponentsProtocol(ComponentsProtocolWrap):
         @cached(**cache_config)
+        async def components_list(
+            self,
+            per_page: int = 50,
+            page: int = 1,
+            *,
+            auth: YandexAuth | None = None,
+        ) -> list[Component]:
+            return await self._original.components_list(
+                per_page=per_page, page=page, auth=auth
+            )
+
+        @cached(**cache_config)
         async def component_get(
             self,
             component_id: int,

--- a/mcp_tracker/tracker/caching/client.py
+++ b/mcp_tracker/tracker/caching/client.py
@@ -5,9 +5,11 @@ from typing import Any
 from aiocache import cached
 
 from mcp_tracker.tracker.proto.common import YandexAuth
+from mcp_tracker.tracker.proto.components import ComponentsProtocolWrap
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocolWrap
 from mcp_tracker.tracker.proto.issues import IssueProtocolWrap
 from mcp_tracker.tracker.proto.queues import QueuesProtocolWrap
+from mcp_tracker.tracker.proto.types.components import Component
 from mcp_tracker.tracker.proto.types.fields import GlobalField, LocalField
 from mcp_tracker.tracker.proto.types.inputs import (
     IssueUpdateFollower,
@@ -47,6 +49,7 @@ class CacheCollection:
     issues: type[IssueProtocolWrap]
     global_data: type[GlobalDataProtocolWrap]
     users: type[UsersProtocolWrap]
+    components: type[ComponentsProtocolWrap]
 
 
 def make_cached_protocols(
@@ -496,9 +499,52 @@ def make_cached_protocols(
         async def user_get_current(self, *, auth: YandexAuth | None = None) -> User:
             return await self._original.user_get_current(auth=auth)
 
+    class CachingComponentsProtocol(ComponentsProtocolWrap):
+        async def component_create(
+            self,
+            queue_id: str,
+            *,
+            name: str,
+            description: str | None = None,
+            auth: YandexAuth | None = None,
+        ) -> Component:
+            return await self._original.component_create(
+                queue_id,
+                name=name,
+                description=description,
+                auth=auth,
+            )
+
+        async def component_update(
+            self,
+            component_id: int,
+            *,
+            name: str | None = None,
+            description: str | None = None,
+            auth: YandexAuth | None = None,
+        ) -> Component:
+            return await self._original.component_update(
+                component_id,
+                name=name,
+                description=description,
+                auth=auth,
+            )
+
+        async def component_delete(
+            self,
+            component_id: int,
+            *,
+            auth: YandexAuth | None = None,
+        ) -> None:
+            return await self._original.component_delete(
+                component_id,
+                auth=auth,
+            )
+
     return CacheCollection(
         queues=CachingQueuesProtocol,
         issues=CachingIssuesProtocol,
         global_data=CachingGlobalDataProtocol,
         users=CachingUsersProtocol,
+        components=CachingComponentsProtocol,
     )

--- a/mcp_tracker/tracker/custom/client.py
+++ b/mcp_tracker/tracker/custom/client.py
@@ -17,9 +17,11 @@ from yarl import URL
 
 from mcp_tracker.tracker.custom.errors import IssueNotFound
 from mcp_tracker.tracker.proto.common import YandexAuth
+from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
+from mcp_tracker.tracker.proto.types.components import Component
 from mcp_tracker.tracker.proto.types.fields import GlobalField, LocalField
 from mcp_tracker.tracker.proto.types.inputs import (
     IssueUpdateFollower,
@@ -57,6 +59,7 @@ QueueList = RootModel[list[Queue]]
 LocalFieldList = RootModel[list[LocalField]]
 QueueTagList = RootModel[list[str]]
 VersionList = RootModel[list[QueueVersion]]
+ComponentList = RootModel[list[Component]]
 IssueLinkList = RootModel[list[IssueLink]]
 IssueList = RootModel[list[Issue]]
 IssueCommentList = RootModel[list[IssueComment]]
@@ -180,7 +183,7 @@ class ServiceAccountStore:
         return IAMTokenInfo(token=iam_token.iam_token)
 
 
-class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProtocol):
+class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProtocol, ComponentsProtocol):
     def __init__(
         self,
         *,
@@ -351,6 +354,83 @@ class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProt
         ) as response:
             response.raise_for_status()
             return Queue.model_validate_json(await response.read())
+
+    async def component_create(
+        self,
+        queue_id: str,
+        *,
+        name: str,
+        description: str | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Component:
+        body: dict[str, Any] = {"name": name, "queue": queue_id}
+        if description is not None:
+            body["description"] = description
+
+        async with self._session.post(
+            "v3/components",
+            headers=await self._build_headers(auth),
+            json=body,
+        ) as response:
+            response.raise_for_status()
+            return Component.model_validate_json(await response.read())
+
+    async def component_get(
+        self,
+        component_id: int,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> Component:
+        async with self._session.get(
+            f"v3/components/{component_id}",
+            headers=await self._build_headers(auth),
+        ) as response:
+            response.raise_for_status()
+            return Component.model_validate_json(await response.read())
+
+    async def component_update(
+        self,
+        component_id: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Component:
+        component = await self.component_get(component_id, auth=auth)
+        if component.version is None:
+            raise ValueError(
+                f"Cannot update component {component_id}: version is missing from API response."
+            )
+
+        body: dict[str, Any] = {}
+        if name is not None:
+            body["name"] = name
+        if description is not None:
+            body["description"] = description
+
+        params: dict[str, int] = {"version": component.version}
+
+        async with self._session.patch(
+            f"v3/components/{component_id}",
+            headers=await self._build_headers(auth),
+            json=body,
+            params=params,
+        ) as response:
+            response.raise_for_status()
+            return Component.model_validate_json(await response.read())
+
+    async def component_delete(
+        self,
+        component_id: int,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> None:
+        async with self._session.delete(
+            f"v3/components/{component_id}",
+            headers=await self._build_headers(auth),
+        ) as response:
+            response.raise_for_status()
+            return None
 
     async def get_global_fields(
         self, *, auth: YandexAuth | None = None

--- a/mcp_tracker/tracker/custom/client.py
+++ b/mcp_tracker/tracker/custom/client.py
@@ -183,7 +183,9 @@ class ServiceAccountStore:
         return IAMTokenInfo(token=iam_token.iam_token)
 
 
-class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProtocol, ComponentsProtocol):
+class TrackerClient(
+    QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProtocol, ComponentsProtocol
+):
     def __init__(
         self,
         *,
@@ -381,12 +383,38 @@ class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProt
             response.raise_for_status()
             return Component.model_validate_json(await response.read())
 
+    async def components_list(
+        self,
+        per_page: int = 50,
+        page: int = 1,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> list[Component]:
+        params = {
+            "perPage": per_page,
+            "page": page,
+        }
+        async with self._session.get(
+            "v3/components",
+            headers=await self._build_headers(auth),
+            params=params,
+        ) as response:
+            response.raise_for_status()
+            return ComponentList.model_validate_json(await response.read()).root
+
     async def component_get(
         self,
         component_id: int,
         *,
         auth: YandexAuth | None = None,
     ) -> Component:
+        """Get a component by ID.
+
+        This endpoint is not documented in the official Yandex Tracker API
+        documentation, but it is used by the official Python client.
+
+        Endpoint: GET https://api.tracker.yandex.net/v3/components/<component_id>
+        """
         async with self._session.get(
             f"v3/components/{component_id}",
             headers=await self._build_headers(auth),
@@ -434,6 +462,13 @@ class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProt
         *,
         auth: YandexAuth | None = None,
     ) -> None:
+        """Delete a component by ID.
+
+        This endpoint is not documented in the official Yandex Tracker API
+        documentation, but it is used by the official Python client.
+
+        Endpoint: DELETE https://api.tracker.yandex.net/v3/components/<component_id>
+        """
         async with self._session.delete(
             f"v3/components/{component_id}",
             headers=await self._build_headers(auth),

--- a/mcp_tracker/tracker/custom/client.py
+++ b/mcp_tracker/tracker/custom/client.py
@@ -361,11 +361,17 @@ class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProt
         *,
         name: str,
         description: str | None = None,
+        lead: str | None = None,
+        assign_auto: bool | None = None,
         auth: YandexAuth | None = None,
     ) -> Component:
         body: dict[str, Any] = {"name": name, "queue": queue_id}
         if description is not None:
             body["description"] = description
+        if lead is not None:
+            body["lead"] = lead
+        if assign_auto is not None:
+            body["assignAuto"] = assign_auto
 
         async with self._session.post(
             "v3/components",
@@ -394,6 +400,7 @@ class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProt
         *,
         name: str | None = None,
         description: str | None = None,
+        lead: str | None = None,
         auth: YandexAuth | None = None,
     ) -> Component:
         component = await self.component_get(component_id, auth=auth)
@@ -407,6 +414,8 @@ class TrackerClient(QueuesProtocol, IssueProtocol, GlobalDataProtocol, UsersProt
             body["name"] = name
         if description is not None:
             body["description"] = description
+        if lead is not None:
+            body["lead"] = lead
 
         params: dict[str, int] = {"version": component.version}
 

--- a/mcp_tracker/tracker/proto/components.py
+++ b/mcp_tracker/tracker/proto/components.py
@@ -6,6 +6,14 @@ from mcp_tracker.tracker.proto.types.components import Component
 
 @runtime_checkable
 class ComponentsProtocol(Protocol):
+    async def components_list(
+        self,
+        per_page: int = 50,
+        page: int = 1,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> list[Component]: ...
+
     async def component_create(
         self,
         queue_id: str,

--- a/mcp_tracker/tracker/proto/components.py
+++ b/mcp_tracker/tracker/proto/components.py
@@ -1,0 +1,47 @@
+from typing import Protocol, runtime_checkable
+
+from mcp_tracker.tracker.proto.common import YandexAuth
+from mcp_tracker.tracker.proto.types.components import Component
+
+
+@runtime_checkable
+class ComponentsProtocol(Protocol):
+    async def component_create(
+        self,
+        queue_id: str,
+        *,
+        name: str,
+        description: str | None = None,
+        lead: str | None = None,
+        assign_auto: bool | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Component: ...
+
+    async def component_get(
+        self,
+        component_id: int,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> Component: ...
+
+    async def component_update(
+        self,
+        component_id: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        lead: str | None = None,
+        auth: YandexAuth | None = None,
+    ) -> Component: ...
+
+    async def component_delete(
+        self,
+        component_id: int,
+        *,
+        auth: YandexAuth | None = None,
+    ) -> None: ...
+
+
+class ComponentsProtocolWrap(ComponentsProtocol):
+    def __init__(self, original: ComponentsProtocol):
+        self._original = original

--- a/mcp_tracker/tracker/proto/types/components.py
+++ b/mcp_tracker/tracker/proto/types/components.py
@@ -1,10 +1,12 @@
 from mcp_tracker.tracker.proto.types.base import BaseTrackerEntity, NoneExcludedField
+from mcp_tracker.tracker.proto.types.refs import QueueReference
 
 
 class Component(BaseTrackerEntity):
-    """Component within a queue."""
+    """Component with a queue."""
 
     id: int | None = NoneExcludedField
     version: int | None = NoneExcludedField
     name: str | None = NoneExcludedField
     description: str | None = NoneExcludedField
+    queue: QueueReference | None = NoneExcludedField

--- a/mcp_tracker/tracker/proto/types/components.py
+++ b/mcp_tracker/tracker/proto/types/components.py
@@ -1,0 +1,10 @@
+from mcp_tracker.tracker.proto.types.base import BaseTrackerEntity, NoneExcludedField
+
+
+class Component(BaseTrackerEntity):
+    """Component within a queue."""
+
+    id: int | None = NoneExcludedField
+    version: int | None = NoneExcludedField
+    name: str | None = NoneExcludedField
+    description: str | None = NoneExcludedField

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -13,9 +13,9 @@ from mcp.types import CallToolResult
 from mcp_tracker.mcp.context import AppContext
 from mcp_tracker.mcp.server import Lifespan, create_mcp_server
 from mcp_tracker.settings import Settings
+from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
-from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
 from mcp_tracker.tracker.proto.users import UsersProtocol
 

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -15,6 +15,7 @@ from mcp_tracker.mcp.server import Lifespan, create_mcp_server
 from mcp_tracker.settings import Settings
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
+from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
 from mcp_tracker.tracker.proto.users import UsersProtocol
 
@@ -126,11 +127,18 @@ def mock_users_protocol() -> AsyncMock:
 
 
 @pytest.fixture
+def mock_components_protocol() -> AsyncMock:
+    """Create a mock ComponentsProtocol."""
+    return AsyncMock(spec=ComponentsProtocol)
+
+
+@pytest.fixture
 def mock_app_context(
     mock_queues_protocol: AsyncMock,
     mock_issues_protocol: AsyncMock,
     mock_fields_protocol: AsyncMock,
     mock_users_protocol: AsyncMock,
+    mock_components_protocol: AsyncMock,
 ) -> AppContext:
     """Create AppContext with mock protocols."""
     return AppContext(
@@ -138,6 +146,7 @@ def mock_app_context(
         issues=mock_issues_protocol,
         fields=mock_fields_protocol,
         users=mock_users_protocol,
+        components=mock_components_protocol,
     )
 
 

--- a/tests/mcp/server/test_server_creation.py
+++ b/tests/mcp/server/test_server_creation.py
@@ -1,7 +1,7 @@
 import pytest
 from mcp.client.session import ClientSession
 
-# Read-only tool names (24 tools) - always registered
+# Read-only tool names (25 tools) - always registered
 READ_ONLY_TOOL_NAMES = [
     # Queue tools (5)
     "queues_get_all",
@@ -27,7 +27,8 @@ READ_ONLY_TOOL_NAMES = [
     "issue_get_checklist",
     "issue_get_transitions",
     "issue_get_changelog",
-    # Component read tools (1)
+    # Component read tools (2)
+    "components_get_all",
     "component_get",
     # User tools (4)
     "users_get_all",

--- a/tests/mcp/server/test_server_creation.py
+++ b/tests/mcp/server/test_server_creation.py
@@ -36,6 +36,9 @@ READ_ONLY_TOOL_NAMES = [
 
 # Write tool names - only registered when not in read-only mode
 WRITE_TOOL_NAMES = [
+    "component_create",
+    "component_update",
+    "component_delete",
     "queue_create_version",
     "issue_execute_transition",
     "issue_close",

--- a/tests/mcp/server/test_server_creation.py
+++ b/tests/mcp/server/test_server_creation.py
@@ -27,6 +27,8 @@ READ_ONLY_TOOL_NAMES = [
     "issue_get_checklist",
     "issue_get_transitions",
     "issue_get_changelog",
+    # Component read tools (1)
+    "component_get",
     # User tools (4)
     "users_get_all",
     "users_search",

--- a/tests/mcp/tools/conftest.py
+++ b/tests/mcp/tools/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mcp_tracker.tracker.proto.types.components import Component
 from mcp_tracker.tracker.proto.types.fields import FieldSchema, GlobalField, LocalField
 from mcp_tracker.tracker.proto.types.issue_types import IssueType
 from mcp_tracker.tracker.proto.types.issues import (
@@ -17,12 +18,12 @@ from mcp_tracker.tracker.proto.types.issues import (
     Worklog,
 )
 from mcp_tracker.tracker.proto.types.priorities import Priority
-from mcp_tracker.tracker.proto.types.components import Component
 from mcp_tracker.tracker.proto.types.queues import Queue, QueueVersion
 from mcp_tracker.tracker.proto.types.refs import (
     IssueReference,
     IssueTypeReference,
     PriorityReference,
+    QueueReference,
     StatusReference,
     UserReference,
 )
@@ -84,6 +85,7 @@ def sample_queue_component() -> Component:
         id=111175,
         name="Test Component",
         description="A test component",
+        queue=QueueReference(id="12345", key="TEST", display="Test Queue"),
     )
 
 

--- a/tests/mcp/tools/conftest.py
+++ b/tests/mcp/tools/conftest.py
@@ -17,6 +17,7 @@ from mcp_tracker.tracker.proto.types.issues import (
     Worklog,
 )
 from mcp_tracker.tracker.proto.types.priorities import Priority
+from mcp_tracker.tracker.proto.types.components import Component
 from mcp_tracker.tracker.proto.types.queues import Queue, QueueVersion
 from mcp_tracker.tracker.proto.types.refs import (
     IssueReference,
@@ -74,6 +75,16 @@ def sample_queues(sample_queue: Queue) -> list[Queue]:
 def sample_queue_tags() -> list[str]:
     """Sample queue tags for testing."""
     return ["bug", "feature", "enhancement", "documentation"]
+
+
+@pytest.fixture
+def sample_queue_component() -> Component:
+    """Sample queue component for testing."""
+    return Component.model_construct(
+        id=111175,
+        name="Test Component",
+        description="A test component",
+    )
 
 
 @pytest.fixture

--- a/tests/mcp/tools/test_component_tools.py
+++ b/tests/mcp/tools/test_component_tools.py
@@ -232,6 +232,7 @@ class TestComponentGet:
         )
 
         assert result.isError
+        mock_components_protocol.component_get.assert_called_once()
 
 
 class TestComponentCreate:
@@ -403,6 +404,7 @@ class TestComponentUpdate:
         )
 
         assert result.isError
+        mock_components_protocol.component_get.assert_called_once()
         mock_components_protocol.component_update.assert_not_called()
 
 
@@ -444,4 +446,5 @@ class TestComponentDelete:
         )
 
         assert result.isError
+        mock_components_protocol.component_get.assert_called_once()
         mock_components_protocol.component_delete.assert_not_called()

--- a/tests/mcp/tools/test_component_tools.py
+++ b/tests/mcp/tools/test_component_tools.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from mcp.client.session import ClientSession
 
 from mcp_tracker.tracker.proto.types.components import Component
+from mcp_tracker.tracker.proto.types.refs import QueueReference
 from tests.mcp.conftest import get_tool_result_content
 
 
@@ -41,6 +42,24 @@ class TestComponentGet:
 
         assert not result.isError
         mock_components_protocol.component_get.assert_called_once()
+
+    async def test_restricted_queue_raises_error(
+        self,
+        client_session_with_limits: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        sample_queue_component.queue = QueueReference(
+            id="999", key="RESTRICTED", display="Restricted Queue"
+        )
+        mock_components_protocol.component_get.return_value = sample_queue_component
+
+        result = await client_session_with_limits.call_tool(
+            "component_get",
+            {"component_id": 111175},
+        )
+
+        assert result.isError
 
 
 class TestComponentCreate:
@@ -132,6 +151,7 @@ class TestComponentUpdate:
         mock_components_protocol: AsyncMock,
         sample_queue_component: Component,
     ) -> None:
+        mock_components_protocol.component_get.return_value = sample_queue_component
         mock_components_protocol.component_update.return_value = sample_queue_component
 
         result = await client_session.call_tool(
@@ -140,6 +160,7 @@ class TestComponentUpdate:
         )
 
         assert not result.isError
+        mock_components_protocol.component_get.assert_called_once()
         mock_components_protocol.component_update.assert_called_once()
         content = get_tool_result_content(result)
         assert isinstance(content, dict)
@@ -151,6 +172,7 @@ class TestComponentUpdate:
         mock_components_protocol: AsyncMock,
         sample_queue_component: Component,
     ) -> None:
+        mock_components_protocol.component_get.return_value = sample_queue_component
         mock_components_protocol.component_update.return_value = sample_queue_component
 
         result = await client_session.call_tool(
@@ -174,6 +196,7 @@ class TestComponentUpdate:
         mock_components_protocol: AsyncMock,
         sample_queue_component: Component,
     ) -> None:
+        mock_components_protocol.component_get.return_value = sample_queue_component
         mock_components_protocol.component_update.return_value = sample_queue_component
 
         result = await client_session.call_tool(
@@ -191,13 +214,34 @@ class TestComponentUpdate:
         content = get_tool_result_content(result)
         assert content["name"] == sample_queue_component.name
 
+    async def test_restricted_queue_raises_error(
+        self,
+        client_session_with_limits: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        sample_queue_component.queue = QueueReference(
+            id="999", key="RESTRICTED", display="Restricted Queue"
+        )
+        mock_components_protocol.component_get.return_value = sample_queue_component
+
+        result = await client_session_with_limits.call_tool(
+            "component_update",
+            {"component_id": 111175, "name": "Updated"},
+        )
+
+        assert result.isError
+        mock_components_protocol.component_update.assert_not_called()
+
 
 class TestComponentDelete:
     async def test_deletes_component(
         self,
         client_session: ClientSession,
         mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
     ) -> None:
+        mock_components_protocol.component_get.return_value = sample_queue_component
         mock_components_protocol.component_delete.return_value = None
 
         result = await client_session.call_tool(
@@ -206,6 +250,26 @@ class TestComponentDelete:
         )
 
         assert not result.isError
+        mock_components_protocol.component_get.assert_called_once()
         mock_components_protocol.component_delete.assert_called_once()
         call_args = mock_components_protocol.component_delete.call_args
         assert call_args.args[0] == 111175
+
+    async def test_restricted_queue_raises_error(
+        self,
+        client_session_with_limits: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        sample_queue_component.queue = QueueReference(
+            id="999", key="RESTRICTED", display="Restricted Queue"
+        )
+        mock_components_protocol.component_get.return_value = sample_queue_component
+
+        result = await client_session_with_limits.call_tool(
+            "component_delete",
+            {"component_id": 111175},
+        )
+
+        assert result.isError
+        mock_components_protocol.component_delete.assert_not_called()

--- a/tests/mcp/tools/test_component_tools.py
+++ b/tests/mcp/tools/test_component_tools.py
@@ -1,0 +1,211 @@
+from unittest.mock import AsyncMock
+
+from mcp.client.session import ClientSession
+
+from mcp_tracker.tracker.proto.types.components import Component
+from tests.mcp.conftest import get_tool_result_content
+
+
+class TestComponentGet:
+    async def test_gets_component(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_get.return_value = sample_queue_component
+
+        result = await client_session.call_tool(
+            "component_get",
+            {"component_id": 111175},
+        )
+
+        assert not result.isError
+        mock_components_protocol.component_get.assert_called_once()
+        content = get_tool_result_content(result)
+        assert isinstance(content, dict)
+        assert content["name"] == sample_queue_component.name
+
+    async def test_gets_component_in_read_only_mode(
+        self,
+        client_session_read_only: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_get.return_value = sample_queue_component
+
+        result = await client_session_read_only.call_tool(
+            "component_get",
+            {"component_id": 111175},
+        )
+
+        assert not result.isError
+        mock_components_protocol.component_get.assert_called_once()
+
+
+class TestComponentCreate:
+    async def test_creates_component(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_create.return_value = sample_queue_component
+
+        result = await client_session.call_tool(
+            "component_create",
+            {"queue_id": "TEST", "name": "Test Component"},
+        )
+
+        assert not result.isError
+        mock_components_protocol.component_create.assert_called_once()
+        content = get_tool_result_content(result)
+        assert isinstance(content, dict)
+        assert content["name"] == sample_queue_component.name
+
+    async def test_with_description(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_create.return_value = sample_queue_component
+
+        result = await client_session.call_tool(
+            "component_create",
+            {
+                "queue_id": "TEST",
+                "name": "Test Component",
+                "description": "A test component",
+            },
+        )
+
+        assert not result.isError
+        call_kwargs = mock_components_protocol.component_create.call_args.kwargs
+        assert call_kwargs["description"] == "A test component"
+        content = get_tool_result_content(result)
+        assert content["name"] == sample_queue_component.name
+
+    async def test_with_lead_and_assign_auto(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_create.return_value = sample_queue_component
+
+        result = await client_session.call_tool(
+            "component_create",
+            {
+                "queue_id": "TEST",
+                "name": "Test Component",
+                "lead": "testuser",
+                "assign_auto": True,
+            },
+        )
+
+        assert not result.isError
+        call_kwargs = mock_components_protocol.component_create.call_args.kwargs
+        assert call_kwargs["lead"] == "testuser"
+        assert call_kwargs["assign_auto"] is True
+        content = get_tool_result_content(result)
+        assert content["name"] == sample_queue_component.name
+
+    async def test_restricted_queue_raises_error(
+        self,
+        client_session_with_limits: ClientSession,
+        mock_components_protocol: AsyncMock,
+    ) -> None:
+        result = await client_session_with_limits.call_tool(
+            "component_create",
+            {"queue_id": "RESTRICTED", "name": "Test"},
+        )
+
+        assert result.isError
+        mock_components_protocol.component_create.assert_not_called()
+
+
+class TestComponentUpdate:
+    async def test_updates_component(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_update.return_value = sample_queue_component
+
+        result = await client_session.call_tool(
+            "component_update",
+            {"component_id": 111175, "name": "Updated Component"},
+        )
+
+        assert not result.isError
+        mock_components_protocol.component_update.assert_called_once()
+        content = get_tool_result_content(result)
+        assert isinstance(content, dict)
+        assert content["name"] == sample_queue_component.name
+
+    async def test_with_description(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_update.return_value = sample_queue_component
+
+        result = await client_session.call_tool(
+            "component_update",
+            {
+                "component_id": 111175,
+                "name": "Updated",
+                "description": "Updated description",
+            },
+        )
+
+        assert not result.isError
+        call_kwargs = mock_components_protocol.component_update.call_args.kwargs
+        assert call_kwargs["description"] == "Updated description"
+        content = get_tool_result_content(result)
+        assert content["name"] == sample_queue_component.name
+
+    async def test_with_lead(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        mock_components_protocol.component_update.return_value = sample_queue_component
+
+        result = await client_session.call_tool(
+            "component_update",
+            {
+                "component_id": 111175,
+                "name": "Updated",
+                "lead": "newlead",
+            },
+        )
+
+        assert not result.isError
+        call_kwargs = mock_components_protocol.component_update.call_args.kwargs
+        assert call_kwargs["lead"] == "newlead"
+        content = get_tool_result_content(result)
+        assert content["name"] == sample_queue_component.name
+
+
+class TestComponentDelete:
+    async def test_deletes_component(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+    ) -> None:
+        mock_components_protocol.component_delete.return_value = None
+
+        result = await client_session.call_tool(
+            "component_delete",
+            {"component_id": 111175},
+        )
+
+        assert not result.isError
+        mock_components_protocol.component_delete.assert_called_once()
+        call_args = mock_components_protocol.component_delete.call_args
+        assert call_args.args[0] == 111175

--- a/tests/mcp/tools/test_component_tools.py
+++ b/tests/mcp/tools/test_component_tools.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import AsyncMock
 
 from mcp.client.session import ClientSession
@@ -5,6 +6,177 @@ from mcp.client.session import ClientSession
 from mcp_tracker.tracker.proto.types.components import Component
 from mcp_tracker.tracker.proto.types.refs import QueueReference
 from tests.mcp.conftest import get_tool_result_content
+
+
+class TestComponentsGetAll:
+    async def test_gets_all_components(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        other_component = Component.model_construct(
+            id=111176,
+            name="Other Component",
+            description="Another component",
+            queue=QueueReference(id="67890", key="OTHER", display="Other Queue"),
+        )
+        mock_components_protocol.components_list.side_effect = [
+            [sample_queue_component, other_component],
+            [],
+        ]
+
+        result = await client_session.call_tool(
+            "components_get_all",
+            {},
+        )
+
+        assert not result.isError
+        assert mock_components_protocol.components_list.call_count == 2
+        content = get_tool_result_content(result)
+        assert isinstance(content, list)
+        assert len(content) == 2
+        assert content[0]["name"] == sample_queue_component.name
+        assert content[1]["name"] == other_component.name
+
+    async def test_filters_by_queue_id(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+        sample_queue_component: Component,
+    ) -> None:
+        other_component = Component.model_construct(
+            id=111176,
+            name="Other Component",
+            queue=QueueReference(id="67890", key="OTHER", display="Other Queue"),
+        )
+        mock_components_protocol.components_list.side_effect = [
+            [sample_queue_component, other_component],
+            [],
+        ]
+
+        result = await client_session.call_tool(
+            "components_get_all",
+            {"queue_id": "TEST"},
+        )
+
+        assert not result.isError
+        content = get_tool_result_content(result)
+        assert isinstance(content, list)
+        assert len(content) == 1
+        assert content[0]["name"] == sample_queue_component.name
+
+    async def test_restricted_queue_filter_raises_error(
+        self,
+        client_session_with_limits: ClientSession,
+        mock_components_protocol: AsyncMock,
+    ) -> None:
+        result = await client_session_with_limits.call_tool(
+            "components_get_all",
+            {"queue_id": "RESTRICTED"},
+        )
+
+        assert result.isError
+        mock_components_protocol.components_list.assert_not_called()
+
+    async def test_applies_queue_limits(
+        self,
+        client_session_with_limits: ClientSession,
+        mock_components_protocol: AsyncMock,
+    ) -> None:
+        allowed_component = Component.model_construct(
+            id=111175,
+            name="Allowed",
+            queue=QueueReference(id="1", key="ALLOWED", display="Allowed Queue"),
+        )
+        restricted_component = Component.model_construct(
+            id=111176,
+            name="Restricted",
+            queue=QueueReference(id="2", key="RESTRICTED", display="Restricted Queue"),
+        )
+        mock_components_protocol.components_list.side_effect = [
+            [allowed_component, restricted_component],
+            [],
+        ]
+
+        result = await client_session_with_limits.call_tool(
+            "components_get_all",
+            {},
+        )
+
+        assert not result.isError
+        content = get_tool_result_content(result)
+        assert isinstance(content, list)
+        assert len(content) == 1
+        assert content[0]["name"] == "Allowed"
+
+    async def test_fetches_multiple_pages(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+    ) -> None:
+        page1_component = Component.model_construct(
+            id=111175,
+            name="Page 1",
+            queue=QueueReference(id="1", key="TEST", display="Test Queue"),
+        )
+        page2_component = Component.model_construct(
+            id=111176,
+            name="Page 2",
+            queue=QueueReference(id="1", key="TEST", display="Test Queue"),
+        )
+        call_count = 0
+
+        async def side_effect(*args: Any, **kwargs: Any) -> list[Component]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [page1_component]
+            if call_count == 2:
+                return [page2_component]
+            return []
+
+        mock_components_protocol.components_list.side_effect = side_effect
+
+        result = await client_session.call_tool(
+            "components_get_all",
+            {},
+        )
+
+        assert not result.isError
+        assert call_count == 3
+        content = get_tool_result_content(result)
+        assert isinstance(content, list)
+        assert len(content) == 2
+        assert content[0]["name"] == "Page 1"
+        assert content[1]["name"] == "Page 2"
+
+    async def test_fetches_specific_page(
+        self,
+        client_session: ClientSession,
+        mock_components_protocol: AsyncMock,
+    ) -> None:
+        page2_component = Component.model_construct(
+            id=111176,
+            name="Page 2",
+            queue=QueueReference(id="1", key="TEST", display="Test Queue"),
+        )
+        mock_components_protocol.components_list.return_value = [page2_component]
+
+        result = await client_session.call_tool(
+            "components_get_all",
+            {"page": 2, "per_page": 10},
+        )
+
+        assert not result.isError
+        mock_components_protocol.components_list.assert_called_once()
+        call_kwargs = mock_components_protocol.components_list.call_args.kwargs
+        assert call_kwargs["page"] == 2
+        assert call_kwargs["per_page"] == 10
+        content = get_tool_result_content(result)
+        assert isinstance(content, list)
+        assert len(content) == 1
+        assert content[0]["name"] == "Page 2"
 
 
 class TestComponentGet:

--- a/tests/tracker/caching/test_components_protocol.py
+++ b/tests/tracker/caching/test_components_protocol.py
@@ -48,6 +48,18 @@ class TestCachingComponentsProtocol:
         )
         assert result == mock_original.components_list.return_value
 
+    async def test_components_list_calls_original_without_auth(
+        self,
+        caching_components_protocol: Any,
+        mock_original: AsyncMock,
+    ) -> None:
+        result = await caching_components_protocol.components_list(per_page=50, page=1)
+
+        mock_original.components_list.assert_called_once_with(
+            per_page=50, page=1, auth=None
+        )
+        assert result == mock_original.components_list.return_value
+
     async def test_component_get_calls_original(
         self,
         caching_components_protocol: Any,
@@ -59,6 +71,16 @@ class TestCachingComponentsProtocol:
         )
 
         mock_original.component_get.assert_called_once_with(111175, auth=yandex_auth)
+        assert result == mock_original.component_get.return_value
+
+    async def test_component_get_calls_original_without_auth(
+        self,
+        caching_components_protocol: Any,
+        mock_original: AsyncMock,
+    ) -> None:
+        result = await caching_components_protocol.component_get(111175)
+
+        mock_original.component_get.assert_called_once_with(111175, auth=None)
         assert result == mock_original.component_get.return_value
 
     async def test_component_create_calls_original(

--- a/tests/tracker/caching/test_components_protocol.py
+++ b/tests/tracker/caching/test_components_protocol.py
@@ -1,0 +1,105 @@
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_tracker.tracker.caching.client import make_cached_protocols
+from mcp_tracker.tracker.proto.common import YandexAuth
+from mcp_tracker.tracker.proto.types.components import Component
+
+
+class TestCachingComponentsProtocol:
+    @pytest.fixture
+    def mock_original(self) -> AsyncMock:
+        original = AsyncMock()
+        original.components_list.return_value = [
+            Component(id=111175, version=1, name="Test Component")
+        ]
+        original.component_get.return_value = Component(
+            id=111175, version=1, name="Test Component"
+        )
+        original.component_create.return_value = Component(
+            id=111176, version=1, name="New Component"
+        )
+        original.component_update.return_value = Component(
+            id=111175, version=2, name="Updated Component"
+        )
+        original.component_delete.return_value = None
+        return original
+
+    @pytest.fixture
+    def caching_components_protocol(self, mock_original: AsyncMock) -> Any:
+        cache_config = {"ttl": 300}
+        cache_collection = make_cached_protocols(cache_config)
+        return cache_collection.components(mock_original)
+
+    async def test_components_list_calls_original(
+        self,
+        caching_components_protocol: Any,
+        mock_original: AsyncMock,
+        yandex_auth: YandexAuth,
+    ) -> None:
+        result = await caching_components_protocol.components_list(
+            per_page=10, page=2, auth=yandex_auth
+        )
+
+        mock_original.components_list.assert_called_once_with(
+            per_page=10, page=2, auth=yandex_auth
+        )
+        assert result == mock_original.components_list.return_value
+
+    async def test_component_get_calls_original(
+        self,
+        caching_components_protocol: Any,
+        mock_original: AsyncMock,
+        yandex_auth: YandexAuth,
+    ) -> None:
+        result = await caching_components_protocol.component_get(
+            111175, auth=yandex_auth
+        )
+
+        mock_original.component_get.assert_called_once_with(111175, auth=yandex_auth)
+        assert result == mock_original.component_get.return_value
+
+    async def test_component_create_calls_original(
+        self,
+        caching_components_protocol: Any,
+        mock_original: AsyncMock,
+    ) -> None:
+        result = await caching_components_protocol.component_create(
+            "TEST", name="New Component"
+        )
+
+        mock_original.component_create.assert_called_once_with(
+            "TEST",
+            name="New Component",
+            description=None,
+            lead=None,
+            assign_auto=None,
+            auth=None,
+        )
+        assert result == mock_original.component_create.return_value
+
+    async def test_component_update_calls_original(
+        self,
+        caching_components_protocol: Any,
+        mock_original: AsyncMock,
+    ) -> None:
+        result = await caching_components_protocol.component_update(
+            111175, name="Updated Component"
+        )
+
+        mock_original.component_update.assert_called_once_with(
+            111175, name="Updated Component", description=None, lead=None, auth=None
+        )
+        assert result == mock_original.component_update.return_value
+
+    async def test_component_delete_calls_original(
+        self,
+        caching_components_protocol: Any,
+        mock_original: AsyncMock,
+    ) -> None:
+        result = await caching_components_protocol.component_delete(111175)
+
+        mock_original.component_delete.assert_called_once_with(111175, auth=None)
+        assert result is None

--- a/tests/tracker/caching/test_protocol_conformance.py
+++ b/tests/tracker/caching/test_protocol_conformance.py
@@ -7,6 +7,7 @@ import pytest
 from mcp_tracker.tracker.caching.client import make_cached_protocols
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
+from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
 from mcp_tracker.tracker.proto.users import UsersProtocol
 
@@ -51,3 +52,11 @@ class TestCachingProtocolConformance:
         instance = cache_collection.users(mock_original)
 
         assert isinstance(instance, UsersProtocol)
+
+    def test_caching_components_implements_protocol(
+        self, cache_config: dict[str, int], mock_original: ComponentsProtocol
+    ) -> None:
+        cache_collection = make_cached_protocols(cache_config)
+        instance = cache_collection.components(mock_original)
+
+        assert isinstance(instance, ComponentsProtocol)

--- a/tests/tracker/caching/test_protocol_conformance.py
+++ b/tests/tracker/caching/test_protocol_conformance.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mcp_tracker.tracker.caching.client import make_cached_protocols
+from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.fields import GlobalDataProtocol
 from mcp_tracker.tracker.proto.issues import IssueProtocol
-from mcp_tracker.tracker.proto.components import ComponentsProtocol
 from mcp_tracker.tracker.proto.queues import QueuesProtocol
 from mcp_tracker.tracker.proto.users import UsersProtocol
 

--- a/tests/tracker/custom/components/test_component_create.py
+++ b/tests/tracker/custom/components/test_component_create.py
@@ -1,0 +1,165 @@
+from aioresponses import aioresponses
+
+from mcp_tracker.tracker.custom.client import TrackerClient
+from mcp_tracker.tracker.proto.common import YandexAuth
+from tests.aioresponses_utils import RequestCapture
+
+
+class TestComponentCreate:
+    async def test_success(self, tracker_client: TrackerClient) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111175",
+            "id": 111175,
+            "version": 1,
+            "name": "Test",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+
+        with aioresponses() as m:
+            m.post(
+                "https://api.tracker.yandex.net/v3/components",
+                payload=component_response,
+                status=201,
+            )
+
+            result = await tracker_client.component_create("TEST", name="Test")
+
+            assert result.name == "Test"
+            assert result.id == 111175
+
+    async def test_with_description(self, tracker_client: TrackerClient) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111176",
+            "id": 111176,
+            "version": 1,
+            "name": "Monitoring",
+            "description": "System monitoring",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+        capture = RequestCapture(payload=component_response, status=201)
+
+        with aioresponses() as m:
+            m.post(
+                "https://api.tracker.yandex.net/v3/components",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.component_create(
+                "TEST", name="Monitoring", description="System monitoring"
+            )
+
+            assert result.name == "Monitoring"
+            assert result.description == "System monitoring"
+
+        capture.assert_called_once()
+        capture.last_request.assert_json_body(
+            {
+                "name": "Monitoring",
+                "queue": "TEST",
+                "description": "System monitoring",
+            }
+        )
+
+    async def test_with_lead_and_assign_auto(
+        self, tracker_client: TrackerClient
+    ) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111178",
+            "id": 111178,
+            "version": 1,
+            "name": "LeadTest",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "lead": {
+                "self": "https://api.tracker.yandex.net/v3/users/123",
+                "id": "123",
+                "display": "Test User",
+            },
+            "assignAuto": True,
+        }
+        capture = RequestCapture(payload=component_response, status=201)
+
+        with aioresponses() as m:
+            m.post(
+                "https://api.tracker.yandex.net/v3/components",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.component_create(
+                "TEST",
+                name="LeadTest",
+                lead="testuser",
+                assign_auto=True,
+            )
+
+            assert result.name == "LeadTest"
+
+        capture.assert_called_once()
+        capture.last_request.assert_json_body(
+            {
+                "name": "LeadTest",
+                "queue": "TEST",
+                "lead": "testuser",
+                "assignAuto": True,
+            }
+        )
+
+    async def test_with_auth(
+        self, tracker_client: TrackerClient, yandex_auth: YandexAuth
+    ) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111177",
+            "id": 111177,
+            "version": 1,
+            "name": "AuthTest",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/AUTH",
+                "id": "999",
+                "key": "AUTH",
+                "display": "Auth Queue",
+            },
+            "assignAuto": False,
+        }
+        capture = RequestCapture(payload=component_response, status=201)
+
+        with aioresponses() as m:
+            m.post(
+                "https://api.tracker.yandex.net/v3/components",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.component_create(
+                "AUTH", name="AuthTest", auth=yandex_auth
+            )
+
+            assert result.name == "AuthTest"
+
+        capture.assert_called_once()
+        capture.last_request.assert_headers(
+            {
+                "Authorization": "OAuth auth-token",
+                "X-Org-ID": "auth-org",
+            }
+        )
+        capture.last_request.assert_json_body(
+            {
+                "name": "AuthTest",
+                "queue": "AUTH",
+            }
+        )

--- a/tests/tracker/custom/components/test_component_delete.py
+++ b/tests/tracker/custom/components/test_component_delete.py
@@ -1,0 +1,43 @@
+from aioresponses import aioresponses
+
+from mcp_tracker.tracker.custom.client import TrackerClient
+from mcp_tracker.tracker.proto.common import YandexAuth
+from tests.aioresponses_utils import RequestCapture
+
+
+class TestComponentDelete:
+    async def test_success(self, tracker_client: TrackerClient) -> None:
+        with aioresponses() as m:
+            m.delete(
+                "https://api.tracker.yandex.net/v3/components/111175",
+                status=204,
+            )
+
+            result = await tracker_client.component_delete(111175)
+
+            assert result is None
+
+    async def test_with_auth(
+        self, tracker_client: TrackerClient, yandex_auth: YandexAuth
+    ) -> None:
+        capture = RequestCapture(status=204)
+
+        with aioresponses() as m:
+            m.delete(
+                "https://api.tracker.yandex.net/v3/components/111177",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.component_delete(
+                111177, auth=yandex_auth
+            )
+
+            assert result is None
+
+        capture.assert_called_once()
+        capture.last_request.assert_headers(
+            {
+                "Authorization": "OAuth auth-token",
+                "X-Org-ID": "auth-org",
+            }
+        )

--- a/tests/tracker/custom/components/test_component_delete.py
+++ b/tests/tracker/custom/components/test_component_delete.py
@@ -13,9 +13,7 @@ class TestComponentDelete:
                 status=204,
             )
 
-            result = await tracker_client.component_delete(111175)
-
-            assert result is None
+            await tracker_client.component_delete(111175)
 
     async def test_with_auth(
         self, tracker_client: TrackerClient, yandex_auth: YandexAuth
@@ -28,11 +26,7 @@ class TestComponentDelete:
                 callback=capture.callback,
             )
 
-            result = await tracker_client.component_delete(
-                111177, auth=yandex_auth
-            )
-
-            assert result is None
+            await tracker_client.component_delete(111177, auth=yandex_auth)
 
         capture.assert_called_once()
         capture.last_request.assert_headers(

--- a/tests/tracker/custom/components/test_component_get.py
+++ b/tests/tracker/custom/components/test_component_get.py
@@ -1,0 +1,72 @@
+from aioresponses import aioresponses
+
+from mcp_tracker.tracker.custom.client import TrackerClient
+from mcp_tracker.tracker.proto.common import YandexAuth
+from tests.aioresponses_utils import RequestCapture
+
+
+class TestComponentGet:
+    async def test_success(self, tracker_client: TrackerClient) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111175",
+            "id": 111175,
+            "version": 2,
+            "name": "Test Component",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111175",
+                payload=component_response,
+                status=200,
+            )
+
+            result = await tracker_client.component_get(111175)
+
+            assert result.id == 111175
+            assert result.version == 2
+            assert result.name == "Test Component"
+
+    async def test_with_auth(
+        self, tracker_client: TrackerClient, yandex_auth: YandexAuth
+    ) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111177",
+            "id": 111177,
+            "version": 3,
+            "name": "Auth Component",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/AUTH",
+                "id": "999",
+                "key": "AUTH",
+                "display": "Auth Queue",
+            },
+            "assignAuto": False,
+        }
+        capture = RequestCapture(payload=component_response, status=200)
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111177",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.component_get(111177, auth=yandex_auth)
+
+            assert result.id == 111177
+            assert result.version == 3
+
+        capture.assert_called_once()
+        capture.last_request.assert_headers(
+            {
+                "Authorization": "OAuth auth-token",
+                "X-Org-ID": "auth-org",
+            }
+        )

--- a/tests/tracker/custom/components/test_component_update.py
+++ b/tests/tracker/custom/components/test_component_update.py
@@ -112,7 +112,9 @@ class TestComponentUpdate:
                 status=200,
             )
             m.patch(
-                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111175\?.*"),
+                re.compile(
+                    r"https://api\.tracker\.yandex\.net/v3/components/111175\?.*"
+                ),
                 payload=patch_response,
                 status=200,
             )
@@ -163,7 +165,9 @@ class TestComponentUpdate:
                 status=200,
             )
             m.patch(
-                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111175\?.*"),
+                re.compile(
+                    r"https://api\.tracker\.yandex\.net/v3/components/111175\?.*"
+                ),
                 callback=patch_capture.callback,
             )
 
@@ -175,9 +179,7 @@ class TestComponentUpdate:
         patch_capture.last_request.assert_json_body({"name": "OnlyName"})
         patch_capture.last_request.assert_param("version", 2)
 
-    async def test_with_lead(
-        self, tracker_client: TrackerClient
-    ) -> None:
+    async def test_with_lead(self, tracker_client: TrackerClient) -> None:
         get_response = {
             "self": "https://api.tracker.yandex.net/v3/components/111178",
             "id": 111178,
@@ -215,7 +217,9 @@ class TestComponentUpdate:
                 status=200,
             )
             m.patch(
-                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111178\?.*"),
+                re.compile(
+                    r"https://api\.tracker\.yandex\.net/v3/components/111178\?.*"
+                ),
                 callback=patch_capture.callback,
             )
 
@@ -271,7 +275,9 @@ class TestComponentUpdate:
                 status=200,
             )
             m.patch(
-                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111177\?.*"),
+                re.compile(
+                    r"https://api\.tracker\.yandex\.net/v3/components/111177\?.*"
+                ),
                 callback=patch_capture.callback,
             )
 
@@ -314,6 +320,6 @@ class TestComponentUpdate:
 
             try:
                 await tracker_client.component_update(111175, name="Should Fail")
-                assert False, "Expected ValueError"
+                raise AssertionError("Expected ValueError")
             except ValueError as e:
                 assert "version is missing" in str(e)

--- a/tests/tracker/custom/components/test_component_update.py
+++ b/tests/tracker/custom/components/test_component_update.py
@@ -1,77 +1,11 @@
 import re
 
+import pytest
 from aioresponses import aioresponses
 
 from mcp_tracker.tracker.custom.client import TrackerClient
 from mcp_tracker.tracker.proto.common import YandexAuth
 from tests.aioresponses_utils import RequestCapture
-
-
-class TestComponentGet:
-    async def test_success(self, tracker_client: TrackerClient) -> None:
-        component_response = {
-            "self": "https://api.tracker.yandex.net/v3/components/111175",
-            "id": 111175,
-            "version": 2,
-            "name": "Test Component",
-            "queue": {
-                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
-                "id": "12345",
-                "key": "TEST",
-                "display": "Test Queue",
-            },
-            "assignAuto": False,
-        }
-
-        with aioresponses() as m:
-            m.get(
-                "https://api.tracker.yandex.net/v3/components/111175",
-                payload=component_response,
-                status=200,
-            )
-
-            result = await tracker_client.component_get(111175)
-
-            assert result.id == 111175
-            assert result.version == 2
-            assert result.name == "Test Component"
-
-    async def test_with_auth(
-        self, tracker_client: TrackerClient, yandex_auth: YandexAuth
-    ) -> None:
-        component_response = {
-            "self": "https://api.tracker.yandex.net/v3/components/111177",
-            "id": 111177,
-            "version": 3,
-            "name": "Auth Component",
-            "queue": {
-                "self": "https://api.tracker.yandex.net/v3/queues/AUTH",
-                "id": "999",
-                "key": "AUTH",
-                "display": "Auth Queue",
-            },
-            "assignAuto": False,
-        }
-        capture = RequestCapture(payload=component_response, status=200)
-
-        with aioresponses() as m:
-            m.get(
-                "https://api.tracker.yandex.net/v3/components/111177",
-                callback=capture.callback,
-            )
-
-            result = await tracker_client.component_get(111177, auth=yandex_auth)
-
-            assert result.id == 111177
-            assert result.version == 3
-
-        capture.assert_called_once()
-        capture.last_request.assert_headers(
-            {
-                "Authorization": "OAuth auth-token",
-                "X-Org-ID": "auth-org",
-            }
-        )
 
 
 class TestComponentUpdate:
@@ -318,8 +252,5 @@ class TestComponentUpdate:
                 status=200,
             )
 
-            try:
+            with pytest.raises(ValueError, match="version is missing"):
                 await tracker_client.component_update(111175, name="Should Fail")
-                raise AssertionError("Expected ValueError")
-            except ValueError as e:
-                assert "version is missing" in str(e)

--- a/tests/tracker/custom/components/test_component_update.py
+++ b/tests/tracker/custom/components/test_component_update.py
@@ -1,0 +1,319 @@
+import re
+
+from aioresponses import aioresponses
+
+from mcp_tracker.tracker.custom.client import TrackerClient
+from mcp_tracker.tracker.proto.common import YandexAuth
+from tests.aioresponses_utils import RequestCapture
+
+
+class TestComponentGet:
+    async def test_success(self, tracker_client: TrackerClient) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111175",
+            "id": 111175,
+            "version": 2,
+            "name": "Test Component",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111175",
+                payload=component_response,
+                status=200,
+            )
+
+            result = await tracker_client.component_get(111175)
+
+            assert result.id == 111175
+            assert result.version == 2
+            assert result.name == "Test Component"
+
+    async def test_with_auth(
+        self, tracker_client: TrackerClient, yandex_auth: YandexAuth
+    ) -> None:
+        component_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111177",
+            "id": 111177,
+            "version": 3,
+            "name": "Auth Component",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/AUTH",
+                "id": "999",
+                "key": "AUTH",
+                "display": "Auth Queue",
+            },
+            "assignAuto": False,
+        }
+        capture = RequestCapture(payload=component_response, status=200)
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111177",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.component_get(111177, auth=yandex_auth)
+
+            assert result.id == 111177
+            assert result.version == 3
+
+        capture.assert_called_once()
+        capture.last_request.assert_headers(
+            {
+                "Authorization": "OAuth auth-token",
+                "X-Org-ID": "auth-org",
+            }
+        )
+
+
+class TestComponentUpdate:
+    async def test_success(self, tracker_client: TrackerClient) -> None:
+        get_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111175",
+            "id": 111175,
+            "version": 2,
+            "name": "Old Name",
+            "description": "Old description",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+        patch_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111175",
+            "id": 111175,
+            "version": 3,
+            "name": "Updated",
+            "description": "Updated description",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111175",
+                payload=get_response,
+                status=200,
+            )
+            m.patch(
+                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111175\?.*"),
+                payload=patch_response,
+                status=200,
+            )
+
+            result = await tracker_client.component_update(
+                111175, name="Updated", description="Updated description"
+            )
+
+            assert result.name == "Updated"
+            assert result.description == "Updated description"
+            assert result.id == 111175
+
+    async def test_name_only(self, tracker_client: TrackerClient) -> None:
+        get_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111175",
+            "id": 111175,
+            "version": 2,
+            "name": "Old Name",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+        patch_capture = RequestCapture(
+            payload={
+                "self": "https://api.tracker.yandex.net/v3/components/111175",
+                "id": 111175,
+                "version": 3,
+                "name": "OnlyName",
+                "queue": {
+                    "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                    "id": "12345",
+                    "key": "TEST",
+                    "display": "Test Queue",
+                },
+                "assignAuto": False,
+            },
+            status=200,
+        )
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111175",
+                payload=get_response,
+                status=200,
+            )
+            m.patch(
+                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111175\?.*"),
+                callback=patch_capture.callback,
+            )
+
+            result = await tracker_client.component_update(111175, name="OnlyName")
+
+            assert result.name == "OnlyName"
+
+        patch_capture.assert_called_once()
+        patch_capture.last_request.assert_json_body({"name": "OnlyName"})
+        patch_capture.last_request.assert_param("version", 2)
+
+    async def test_with_lead(
+        self, tracker_client: TrackerClient
+    ) -> None:
+        get_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111178",
+            "id": 111178,
+            "version": 2,
+            "name": "Old Name",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+        patch_capture = RequestCapture(
+            payload={
+                "self": "https://api.tracker.yandex.net/v3/components/111178",
+                "id": 111178,
+                "version": 3,
+                "name": "LeadUpdate",
+                "queue": {
+                    "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                    "id": "12345",
+                    "key": "TEST",
+                    "display": "Test Queue",
+                },
+                "assignAuto": False,
+            },
+            status=200,
+        )
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111178",
+                payload=get_response,
+                status=200,
+            )
+            m.patch(
+                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111178\?.*"),
+                callback=patch_capture.callback,
+            )
+
+            result = await tracker_client.component_update(
+                111178, name="LeadUpdate", lead="newlead"
+            )
+
+            assert result.name == "LeadUpdate"
+
+        patch_capture.assert_called_once()
+        patch_capture.last_request.assert_param("version", 2)
+        patch_capture.last_request.assert_json_body(
+            {"name": "LeadUpdate", "lead": "newlead"}
+        )
+
+    async def test_with_auth(
+        self, tracker_client: TrackerClient, yandex_auth: YandexAuth
+    ) -> None:
+        get_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111177",
+            "id": 111177,
+            "version": 5,
+            "name": "Old Auth",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/AUTH",
+                "id": "999",
+                "key": "AUTH",
+                "display": "Auth Queue",
+            },
+            "assignAuto": False,
+        }
+        patch_capture = RequestCapture(
+            payload={
+                "self": "https://api.tracker.yandex.net/v3/components/111177",
+                "id": 111177,
+                "version": 6,
+                "name": "AuthUpdate",
+                "queue": {
+                    "self": "https://api.tracker.yandex.net/v3/queues/AUTH",
+                    "id": "999",
+                    "key": "AUTH",
+                    "display": "Auth Queue",
+                },
+                "assignAuto": False,
+            },
+            status=200,
+        )
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111177",
+                payload=get_response,
+                status=200,
+            )
+            m.patch(
+                re.compile(r"https://api\.tracker\.yandex\.net/v3/components/111177\?.*"),
+                callback=patch_capture.callback,
+            )
+
+            result = await tracker_client.component_update(
+                111177, name="AuthUpdate", auth=yandex_auth
+            )
+
+            assert result.name == "AuthUpdate"
+
+        patch_capture.assert_called_once()
+        patch_capture.last_request.assert_headers(
+            {
+                "Authorization": "OAuth auth-token",
+                "X-Org-ID": "auth-org",
+            }
+        )
+        patch_capture.last_request.assert_param("version", 5)
+        patch_capture.last_request.assert_json_body({"name": "AuthUpdate"})
+
+    async def test_missing_version_raises(self, tracker_client: TrackerClient) -> None:
+        get_response = {
+            "self": "https://api.tracker.yandex.net/v3/components/111175",
+            "id": 111175,
+            "name": "No Version",
+            "queue": {
+                "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                "id": "12345",
+                "key": "TEST",
+                "display": "Test Queue",
+            },
+            "assignAuto": False,
+        }
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components/111175",
+                payload=get_response,
+                status=200,
+            )
+
+            try:
+                await tracker_client.component_update(111175, name="Should Fail")
+                assert False, "Expected ValueError"
+            except ValueError as e:
+                assert "version is missing" in str(e)

--- a/tests/tracker/custom/components/test_components_list.py
+++ b/tests/tracker/custom/components/test_components_list.py
@@ -1,0 +1,127 @@
+from aioresponses import aioresponses
+
+from mcp_tracker.tracker.custom.client import TrackerClient
+from mcp_tracker.tracker.proto.common import YandexAuth
+from tests.aioresponses_utils import RequestCapture
+
+
+class TestComponentsList:
+    async def test_success(self, tracker_client: TrackerClient) -> None:
+        components_response = [
+            {
+                "self": "https://api.tracker.yandex.net/v3/components/111175",
+                "id": 111175,
+                "version": 1,
+                "name": "Test",
+                "queue": {
+                    "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                    "id": "12345",
+                    "key": "TEST",
+                    "display": "Test Queue",
+                },
+                "assignAuto": False,
+            },
+            {
+                "self": "https://api.tracker.yandex.net/v3/components/111176",
+                "id": 111176,
+                "version": 1,
+                "name": "Monitoring",
+                "queue": {
+                    "self": "https://api.tracker.yandex.net/v3/queues/OTHER",
+                    "id": "67890",
+                    "key": "OTHER",
+                    "display": "Other Queue",
+                },
+                "assignAuto": False,
+            },
+        ]
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components?page=1&perPage=50",
+                payload=components_response,
+                status=200,
+            )
+
+            result = await tracker_client.components_list()
+
+            assert len(result) == 2
+            assert result[0].name == "Test"
+            assert result[0].queue is not None
+            assert result[0].queue.key == "TEST"
+            assert result[1].queue is not None
+            assert result[1].queue.key == "OTHER"
+
+    async def test_with_pagination(self, tracker_client: TrackerClient) -> None:
+        components_response = [
+            {
+                "self": "https://api.tracker.yandex.net/v3/components/111175",
+                "id": 111175,
+                "version": 1,
+                "name": "Test",
+                "queue": {
+                    "self": "https://api.tracker.yandex.net/v3/queues/TEST",
+                    "id": "12345",
+                    "key": "TEST",
+                    "display": "Test Queue",
+                },
+                "assignAuto": False,
+            }
+        ]
+        capture = RequestCapture(payload=components_response, status=200)
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components?page=2&perPage=10",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.components_list(per_page=10, page=2)
+
+            assert len(result) == 1
+            assert result[0].name == "Test"
+
+        capture.assert_called_once()
+        capture.last_request.assert_param("perPage", 10)
+        capture.last_request.assert_param("page", 2)
+
+    async def test_with_auth(
+        self, tracker_client: TrackerClient, yandex_auth: YandexAuth
+    ) -> None:
+        components_response = [
+            {
+                "self": "https://api.tracker.yandex.net/v3/components/111177",
+                "id": 111177,
+                "version": 1,
+                "name": "AuthTest",
+                "queue": {
+                    "self": "https://api.tracker.yandex.net/v3/queues/AUTH",
+                    "id": "999",
+                    "key": "AUTH",
+                    "display": "Auth Queue",
+                },
+                "assignAuto": False,
+            }
+        ]
+        capture = RequestCapture(payload=components_response, status=200)
+
+        with aioresponses() as m:
+            m.get(
+                "https://api.tracker.yandex.net/v3/components?page=1&perPage=50",
+                callback=capture.callback,
+            )
+
+            result = await tracker_client.components_list(auth=yandex_auth)
+
+            assert len(result) == 1
+            assert result[0].name == "AuthTest"
+
+        capture.assert_called_once()
+        capture.last_request.assert_param("perPage", 50)
+        capture.last_request.assert_param("page", 1)
+        capture.last_request.assert_headers(
+            {
+                "Authorization": "OAuth auth-token",
+                "X-Org-ID": "auth-org",
+            }
+        )


### PR DESCRIPTION
## Description

  Implemented queue component management in the Yandex Tracker MCP server. Added full CRUD support for queue components: Create, Get, Update, and Delete. [Doc components](https://yandex.ru/support/tracker/ru/manager/components.html) , [doc api](https://yandex.ru/support/tracker/ru/api-ref/queues/get-components)

  ## What's New

  ### MCP Tools

  | Tool | Description | Mode |
  |------|-------------|------|
  | `component_create` | Create a new component in a Yandex Tracker queue | Write |
  | `component_update` | Update an existing component (name, description) | Write |
  | `component_delete` | Delete a component from Yandex Tracker | Write |

  **Note:** Write tools are only registered when `tracker_read_only=false`.

  ### API Client (`TrackerClient`)

  - `component_create(queue_id, name, description)` — POST `/v3/components`
  - `component_get(component_id)` — GET `/v3/components/{id}`
  - `component_update(component_id, name, description)` — PATCH `/v3/components/{id}` with optimistic concurrency control via `version`
  - `component_delete(component_id)` — DELETE `/v3/components/{id}`

  ### Architecture Integration

  - Added `ComponentsProtocol` to `AppContext`
  - Added caching support via `CachingComponentsProtocol` in `CacheCollection`
  - Updated `manifest.json` with new tool descriptions
  - `TrackerClient` now implements `ComponentsProtocol`

  ## Tests

  - Added fixtures: `mock_components_protocol`, `sample_queue_component`
  - `mock_app_context` now includes `components`
  - Write tools `component_create`, `component_update`, `component_delete` are covered in `test_server_creation`

