### PR TITLE
fix: resolve issue comment model references

### DIFF
--- a/mcp_tracker/tracker/proto/types/issues.py
+++ b/mcp_tracker/tracker/proto/types/issues.py
@@ -63,6 +63,10 @@ IssueFieldsEnum = Enum(  # type: ignore[misc]
 )
 
 
+class MaillistReference(BaseReference):
+    display: str | None = None
+
+
 class IssueComment(CreatedUpdatedMixin, BaseTrackerEntity):
     id: int
     long_id: str | None = Field(
@@ -78,15 +82,11 @@ class IssueComment(CreatedUpdatedMixin, BaseTrackerEntity):
         validation_alias=AliasChoices("summonees", "summonees"),
         exclude_if=none_excluder,
     )
-    maillist_summonees: list["MaillistReference"] | None = Field(
+    maillist_summonees: list[MaillistReference] | None = Field(
         None,
         validation_alias=AliasChoices("maillistSummonees", "maillist_summonees"),
         exclude_if=none_excluder,
     )
-
-
-class MaillistReference(BaseReference):
-    display: str | None = None
 
 
 class LinkTypeReference(BaseReference):

--- a/tests/tracker/custom/issues/test_issue_comment_model.py
+++ b/tests/tracker/custom/issues/test_issue_comment_model.py
@@ -1,0 +1,5 @@
+from mcp_tracker.tracker.proto.types.issues import IssueComment
+
+
+def test_model_is_complete_after_import() -> None:
+    assert IssueComment.__pydantic_complete__


### PR DESCRIPTION
## Summary

Fixes `IssueComment` model initialization when MCP serializes issue comments.

`IssueComment` referenced `MaillistReference` before it was defined, leaving the Pydantic model incomplete at import time. This could result in a `MockValSer` serialization error from `issue_get_comments`.

The reference model is now declared before `IssueComment`, so Pydantic builds the schema eagerly.

## Tests

- Added a regression test that verifies `IssueComment` is complete immediately after import.
- Ran comment read/write scenarios and MCP read-tool tests: `14 passed`.
- Ran `ruff check` and `ruff format --check`.