### PR TITLE
fix: accept string version values on Issue (named/non-numeric Tracker versions)

### DIFF
--- a/mcp_tracker/tracker/proto/types/issues.py
+++ b/mcp_tracker/tracker/proto/types/issues.py
@@ -26,7 +26,8 @@ class Issue(CreatedUpdatedMixin, BaseTrackerEntity):
     model_config = ConfigDict(
         extra="allow",
     )
-    version: int | None = NoneExcludedField
+    # Named (non-numeric) Tracker versions return this as a string, e.g. "MVP-0".
+    version: int | str | None = NoneExcludedField
     unique: str | None = NoneExcludedField
     key: str | None = NoneExcludedField
     summary: str | None = NoneExcludedField

--- a/tests/tracker/custom/issues/test_issues_find.py
+++ b/tests/tracker/custom/issues/test_issues_find.py
@@ -48,3 +48,21 @@ class TestIssuesFind:
         capture.assert_called_once()
         capture.last_request.assert_params({"perPage": 50, "page": 2})
         capture.last_request.assert_json_field("query", "Queue: TEST")
+
+    async def test_with_text_based_version(
+        self, tracker_client: TrackerClient, sample_issue_data: dict[str, Any]
+    ) -> None:
+        """Queues with named versions (e.g. "MVP-0") return version as a string."""
+        sample_issue_data["version"] = "MVP-0"
+        search_response = [sample_issue_data]
+
+        with aioresponses() as m:
+            m.post(
+                "https://api.tracker.yandex.net/v3/issues/_search?page=1&perPage=15",
+                payload=search_response,
+            )
+
+            result = await tracker_client.issues_find("Queue: TEST")
+
+            assert len(result) == 1
+            assert result[0].version == "MVP-0"


### PR DESCRIPTION
## Root cause

`Issue.version` is typed `int | None`, matching Yandex Tracker's default integer revision number. A queue configured with named (non-numeric) versions, e.g. `"MVP-0"` or `"RELEASE 1.0.0"`, returns this field as a string instead, so pydantic rejects the whole issue with a validation error. This makes `issues_find` (and any other tool that returns `Issue` objects) fail for every issue in such a queue, exactly as reported.

## Fix

Widen the type to `int | str | None`. `version` has no other reader in this codebase, so this only relaxes what the model accepts; nothing downstream assumes it is numeric.

## Verification

- New test `test_with_text_based_version` (`tests/tracker/custom/issues/test_issues_find.py`) reproduces the reported traceback (`version='MVP-0'` -> `int_parsing` error) on current `main`, and passes on this branch.
- Full suite: `uv run pytest .`, 584 passed.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check .`, `uv run mypy .` all clean.

Not verified: I don't have a live Tracker instance, so this is confirmed against the exact payload shape from the issue's traceback rather than a real API response.

Fixes #21
